### PR TITLE
Allow selectively disabling vectorization

### DIFF
--- a/lib/KangarooTwelve.c
+++ b/lib/KangarooTwelve.c
@@ -574,6 +574,7 @@ void KangarooTwelve_SetProcessorCapabilities(void)
     K12_enableAVX512 = (features & AVX512F) && (features & AVX512VL) && !K12_AVX512_requested_disabled;
 }
 
+#ifndef KeccakP1600_disableParallelism
 int KangarooTwelve_DisableSSSE3(void) {
     KangarooTwelve_SetProcessorCapabilities();
     K12_SSSE3_requested_disabled = 1;
@@ -613,3 +614,4 @@ void KangarooTwelve_EnableAllCpuFeatures(void) {
     K12_AVX512_requested_disabled = 0;
     KangarooTwelve_SetProcessorCapabilities();
 }
+#endif  // KeccakP1600_disableParallelism

--- a/lib/KangarooTwelve.c
+++ b/lib/KangarooTwelve.c
@@ -14,6 +14,9 @@ http://creativecommons.org/publicdomain/zero/1.0/
 #include "KangarooTwelve.h"
 
 void KangarooTwelve_SetProcessorCapabilities(void);
+int K12_SSSE3_requested_disabled = 0;
+int K12_AVX2_requested_disabled = 0;
+int K12_AVX512_requested_disabled = 0;
 int K12_enableSSSE3 = 0;
 int K12_enableAVX2 = 0;
 int K12_enableAVX512 = 0;
@@ -566,7 +569,47 @@ static enum cpu_feature
 void KangarooTwelve_SetProcessorCapabilities(void)
 {
     enum cpu_feature features = get_cpu_features();
-    K12_enableSSSE3 = (features & SSSE3);
-    K12_enableAVX2 = (features & AVX2);
-    K12_enableAVX512 = (features & AVX512F) && (features & AVX512VL);
+    K12_enableSSSE3 = (features & SSSE3) && !K12_SSSE3_requested_disabled;
+    K12_enableAVX2 = (features & AVX2) && !K12_AVX2_requested_disabled;
+    K12_enableAVX512 = (features & AVX512F) && (features & AVX512VL) && !K12_AVX512_requested_disabled;
+}
+
+int KangarooTwelve_DisableSSSE3(void) {
+    KangarooTwelve_SetProcessorCapabilities();
+    K12_SSSE3_requested_disabled = 1;
+    if (K12_enableSSSE3) {
+        KangarooTwelve_SetProcessorCapabilities();
+        return 1;  // SSSE3 was disabled on this call.
+    } else {
+        return 0;  // Nothing changed.
+    }
+}
+
+int KangarooTwelve_DisableAVX2(void) {
+    KangarooTwelve_SetProcessorCapabilities();
+    K12_AVX2_requested_disabled = 1;
+    if (K12_enableAVX2) {
+        KangarooTwelve_SetProcessorCapabilities();
+        return 1;  // AVX2 was disabled on this call.
+    } else {
+        return 0;  // Nothing changed.
+    }
+}
+
+int KangarooTwelve_DisableAVX512(void) {
+    KangarooTwelve_SetProcessorCapabilities();
+    K12_AVX512_requested_disabled = 1;
+    if (K12_enableAVX512) {
+        KangarooTwelve_SetProcessorCapabilities();
+        return 1;  // AVX512 was disabled on this call.
+    } else {
+        return 0;  // Nothing changed.
+    }
+}
+
+void KangarooTwelve_EnableAllCpuFeatures(void) {
+    K12_SSSE3_requested_disabled = 0;
+    K12_AVX2_requested_disabled = 0;
+    K12_AVX512_requested_disabled = 0;
+    KangarooTwelve_SetProcessorCapabilities();
 }

--- a/lib/KangarooTwelve.c
+++ b/lib/KangarooTwelve.c
@@ -13,7 +13,7 @@ http://creativecommons.org/publicdomain/zero/1.0/
 #include <stdint.h>
 #include "KangarooTwelve.h"
 
-void KangarooTwelve_SetProcessorCapabilities();
+void KangarooTwelve_SetProcessorCapabilities(void);
 int K12_enableSSSE3 = 0;
 int K12_enableAVX2 = 0;
 int K12_enableAVX512 = 0;
@@ -512,7 +512,7 @@ enum cpu_feature {
 static enum cpu_feature g_cpu_features = UNDEFINED;
 
 static enum cpu_feature
-    get_cpu_features() {
+    get_cpu_features(void) {
 
   if (g_cpu_features != UNDEFINED) {
     return g_cpu_features;
@@ -563,7 +563,7 @@ static enum cpu_feature
   }
 }
 
-void KangarooTwelve_SetProcessorCapabilities()
+void KangarooTwelve_SetProcessorCapabilities(void)
 {
     enum cpu_feature features = get_cpu_features();
     K12_enableSSSE3 = (features & SSSE3);

--- a/lib/KangarooTwelve.h
+++ b/lib/KangarooTwelve.h
@@ -107,6 +107,7 @@ int KangarooTwelve_Final(KangarooTwelve_Instance *ktInstance, unsigned char *out
   */
 int KangarooTwelve_Squeeze(KangarooTwelve_Instance *ktInstance, unsigned char *output, size_t outputByteLen);
 
+#ifndef KeccakP1600_disableParallelism
 /**
   * Functions to selectively disable the use of CPU features. Should be rarely
   * needed; if you're not sure this is what you want, don't worry about it.
@@ -130,5 +131,6 @@ int KangarooTwelve_DisableSSSE3(void);
   * always has no effect if no CPU features have been explicitly disabled.
   */
 void KangarooTwelve_EnableAllCpuFeatures(void);
+#endif  // KeccakP1600_disableParallelism
 
 #endif

--- a/lib/KangarooTwelve.h
+++ b/lib/KangarooTwelve.h
@@ -107,4 +107,28 @@ int KangarooTwelve_Final(KangarooTwelve_Instance *ktInstance, unsigned char *out
   */
 int KangarooTwelve_Squeeze(KangarooTwelve_Instance *ktInstance, unsigned char *output, size_t outputByteLen);
 
+/**
+  * Functions to selectively disable the use of CPU features. Should be rarely
+  * needed; if you're not sure this is what you want, don't worry about it.
+  *
+  * This can be useful in an environment where it is detrimental to online large
+  * vector units on the CPU, since doing so can lead to downclocking,
+  * performance hits in other threads sharing the same CPU core, and short
+  * delays while the CPU's power license is increased to online the vector unit.
+  * In the majority of situations, however, this should rarely matter and it is
+  * often the case that the performance difference will be a wash or even an
+  * overall improvement despite the downsides.
+  * @return 1 if the feature was enabled and available and has been turned off,
+  *     0 if it was already disabled or unavailable.
+  */
+int KangarooTwelve_DisableAVX512(void);
+int KangarooTwelve_DisableAVX2(void);
+int KangarooTwelve_DisableSSSE3(void);
+
+/**
+  * Function to reset all CPU features to enabled-if-available. Calling this
+  * always has no effect if no CPU features have been explicitly disabled.
+  */
+void KangarooTwelve_EnableAllCpuFeatures(void);
+
 #endif

--- a/lib/Optimized64/KeccakP-1600-AVX2.s
+++ b/lib/Optimized64/KeccakP-1600-AVX2.s
@@ -11,7 +11,8 @@
 # (https://github.com/dot-asm/cryptogams/blob/master/x86_64/keccak1600-avx2.pl).
 # The rest of the code was written by Ronny Van Keer.
 
-.arch .avx2
+# This directive is unsupported by clang.
+# .arch .avx2
 
 .text
 

--- a/lib/Optimized64/KeccakP-1600-AVX512.s
+++ b/lib/Optimized64/KeccakP-1600-AVX512.s
@@ -11,7 +11,8 @@
 # (https://github.com/dot-asm/cryptogams/blob/master/x86_64/keccak1600-avx512.pl).
 # The rest of the code was written by Ronny Van Keer.
 
-.arch .avx512f
+# This directive is unsupported by clang.
+# .arch .avx512f
 
 .text
 

--- a/tests/testKangarooTwelve.c
+++ b/tests/testKangarooTwelve.c
@@ -315,6 +315,7 @@ void testKangarooTwelve(void)
 #endif
     const unsigned char* checksum = (const unsigned char*)"\x61\x4d\x7a\xf8\xd5\xcc\xd0\xe1\x02\x53\x7d\x21\x5e\x39\x05\xed";
 
+#ifndef KeccakP1600_disableParallelism
     // Read feature availability
     KangarooTwelve_EnableAllCpuFeatures();
     int cpu_has_AVX512 = KangarooTwelve_DisableAVX512();
@@ -323,8 +324,10 @@ void testKangarooTwelve(void)
 
     // Test without vectorization
     printf(" - Testing without vectorization:\n");
+#endif
     selfTestKangarooTwelve(checksum);
 
+#ifndef KeccakP1600_disableParallelism
     // Test with SSSE3 only if it's available
     if (cpu_has_SSSE3) {
         printf("\n - Testing with SSSE3 enabled:\n");
@@ -346,4 +349,5 @@ void testKangarooTwelve(void)
         KangarooTwelve_EnableAllCpuFeatures();
         selfTestKangarooTwelve(checksum);
     }
+#endif
 }

--- a/tests/testKangarooTwelve.c
+++ b/tests/testKangarooTwelve.c
@@ -313,6 +313,37 @@ void testKangarooTwelve(void)
     printKangarooTwelveTestVectors();
     writeTestKangarooTwelve("KangarooTwelve.txt");
 #endif
+    const unsigned char* checksum = (const unsigned char*)"\x61\x4d\x7a\xf8\xd5\xcc\xd0\xe1\x02\x53\x7d\x21\x5e\x39\x05\xed";
 
-    selfTestKangarooTwelve((const unsigned char *)"\x61\x4d\x7a\xf8\xd5\xcc\xd0\xe1\x02\x53\x7d\x21\x5e\x39\x05\xed");
+    // Read feature availability
+    KangarooTwelve_EnableAllCpuFeatures();
+    int cpu_has_AVX512 = KangarooTwelve_DisableAVX512();
+    int cpu_has_AVX2 = KangarooTwelve_DisableAVX2();
+    int cpu_has_SSSE3 = KangarooTwelve_DisableSSSE3();
+
+    // Test without vectorization
+    printf(" - Testing without vectorization:\n");
+    selfTestKangarooTwelve(checksum);
+
+    // Test with SSSE3 only if it's available
+    if (cpu_has_SSSE3) {
+        printf("\n - Testing with SSSE3 enabled:\n");
+        KangarooTwelve_EnableAllCpuFeatures();
+        KangarooTwelve_DisableAVX512();
+        KangarooTwelve_DisableAVX2();
+        selfTestKangarooTwelve(checksum);
+    }
+    // Test with SSSE3 and AVX2 if they're available
+    if (cpu_has_AVX2) {
+        printf("\n - Testing with AVX2 enabled:\n");
+        KangarooTwelve_EnableAllCpuFeatures();
+        KangarooTwelve_DisableAVX512();
+        selfTestKangarooTwelve(checksum);
+    }
+    // Finally, test with everything enabled if we have AVX512
+    if (cpu_has_AVX512) {
+        printf("\n - Testing with AVX512 enabled:\n");
+        KangarooTwelve_EnableAllCpuFeatures();
+        selfTestKangarooTwelve(checksum);
+    }
 }

--- a/tests/testPerformance.c
+++ b/tests/testPerformance.c
@@ -135,7 +135,36 @@ void testKangarooTwelvePerformance()
 }
 void testPerformance()
 {
+    // Read feature availability
+    KangarooTwelve_EnableAllCpuFeatures();
+    int cpu_has_AVX512 = KangarooTwelve_DisableAVX512();
+    int cpu_has_AVX2 = KangarooTwelve_DisableAVX2();
+    int cpu_has_SSSE3 = KangarooTwelve_DisableSSSE3();
+
+    // Test without vectorization
     testKangarooTwelvePerformance();
+
+    // Test with SSSE3 only if it's available
+    if (cpu_has_SSSE3) {
+        printf("\n");
+        KangarooTwelve_EnableAllCpuFeatures();
+        KangarooTwelve_DisableAVX512();
+        KangarooTwelve_DisableAVX2();
+        testKangarooTwelvePerformance();
+    }
+    // Test with SSSE3 and AVX2 if they're available
+    if (cpu_has_AVX2) {
+        printf("\n");
+        KangarooTwelve_EnableAllCpuFeatures();
+        KangarooTwelve_DisableAVX512();
+        testKangarooTwelvePerformance();
+    }
+    // Finally, test with everything enabled if we have AVX512
+    if (cpu_has_AVX512) {
+        printf("\n");
+        KangarooTwelve_EnableAllCpuFeatures();
+        testKangarooTwelvePerformance();
+    }
 }
 
 void bubbleSort(double *list, unsigned int size)

--- a/tests/testPerformance.c
+++ b/tests/testPerformance.c
@@ -135,15 +135,18 @@ void testKangarooTwelvePerformance()
 }
 void testPerformance()
 {
+#ifndef KeccakP1600_disableParallelism
     // Read feature availability
     KangarooTwelve_EnableAllCpuFeatures();
     int cpu_has_AVX512 = KangarooTwelve_DisableAVX512();
     int cpu_has_AVX2 = KangarooTwelve_DisableAVX2();
     int cpu_has_SSSE3 = KangarooTwelve_DisableSSSE3();
+#endif
 
     // Test without vectorization
     testKangarooTwelvePerformance();
 
+#ifndef KeccakP1600_disableParallelism
     // Test with SSSE3 only if it's available
     if (cpu_has_SSSE3) {
         printf("\n");
@@ -165,6 +168,7 @@ void testPerformance()
         KangarooTwelve_EnableAllCpuFeatures();
         testKangarooTwelvePerformance();
     }
+#endif
 }
 
 void bubbleSort(double *list, unsigned int size)


### PR DESCRIPTION
In rare cases it may be desirable to disable wider instruction sets; in environments where AVX512 instructions are otherwise rare and/or performance in threads sharing the same core is more critical than the performance of the hasher.

A greater benefit resulting from this is that it allows us to test all the available implementations for integrity in the same runtime by changing the enabled instruction sets on the fly. This stands out in the performance test, where we can demonstrate the performance delta between different implementations.

Of note: I also delete the `.arch` directives in the AVX assembly files; this appears to have no effect on the resulting program with gcc, and makes the code work with clang 7+. Please let me know if there are targets or compilers where this breaks something!