### PR TITLE
re-unify external & internal structs

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -61,6 +61,7 @@ http://creativecommons.org/publicdomain/zero/1.0/
         <c>tests/testKangarooTwelve.c</c>
         <h>tests/testKangarooTwelve.h</h>
         <gcc>-lm</gcc>
+        <gcc>-DKeccakP1600_enable_simd_options</gcc>
     </fragment>
 
     <!-- To make a library -->

--- a/lib/KangarooTwelve.c
+++ b/lib/KangarooTwelve.c
@@ -20,21 +20,21 @@ http://creativecommons.org/publicdomain/zero/1.0/
 #include "KangarooTwelve.h"
 #include "KeccakP-1600-SnP.h"
 
+#ifdef KeccakP1600_disableParallelism
+#undef KeccakP1600_enable_simd_options
+#endif  // KeccakP1600_disableParallelism
+
 void KangarooTwelve_SetProcessorCapabilities(void);
+#ifdef KeccakP1600_enable_simd_options
 int K12_SSSE3_requested_disabled = 0;
 int K12_AVX2_requested_disabled = 0;
 int K12_AVX512_requested_disabled = 0;
+#endif  // KeccakP1600_enable_simd_options
 int K12_enableSSSE3 = 0;
 int K12_enableAVX2 = 0;
 int K12_enableAVX512 = 0;
 
 /* ---------------------------------------------------------------- */
-
-ALIGN(KeccakP1600_stateAlignment) typedef struct Opaque_KangarooTwelve_FStruct {
-    uint8_t state[KeccakP1600_stateSizeInBytes];
-    uint8_t byteIOIndex;
-    uint8_t squeezing;
-} Opaque_KangarooTwelve_F;
 
 #define K12_security        128
 #define K12_capacity        (2*K12_security)
@@ -43,14 +43,14 @@ ALIGN(KeccakP1600_stateAlignment) typedef struct Opaque_KangarooTwelve_FStruct {
 #define K12_rateInBytes     (K12_rate/8)
 #define K12_rateInLanes     (K12_rate/64)
 
-static void KangarooTwelve_F_Initialize(Opaque_KangarooTwelve_F *instance)
+static void KangarooTwelve_F_Initialize(KangarooTwelve_F *instance)
 {
     KeccakP1600_Initialize(instance->state);
     instance->byteIOIndex = 0;
     instance->squeezing = 0;
 }
 
-static void KangarooTwelve_F_Absorb(Opaque_KangarooTwelve_F *instance, const unsigned char *data, size_t dataByteLen)
+static void KangarooTwelve_F_Absorb(KangarooTwelve_F *instance, const unsigned char *data, size_t dataByteLen)
 {
     size_t i, j;
     uint8_t partialBlock;
@@ -75,13 +75,13 @@ static void KangarooTwelve_F_Absorb(Opaque_KangarooTwelve_F *instance, const uns
                 curData+=rateInBytes;
             }
             i = dataByteLen - j;
-        }
-        else {
+        } else {
             /* normal lane: using the message queue */
-            if ((dataByteLen - i) + instance->byteIOIndex > (size_t)rateInBytes)
+            if ((dataByteLen - i) + instance->byteIOIndex > (size_t)rateInBytes) {
                 partialBlock = rateInBytes-instance->byteIOIndex;
-            else
+            } else {
                 partialBlock = (uint8_t)(dataByteLen - i);
+            }
             i += partialBlock;
 
             KeccakP1600_AddBytes(instance->state, curData, instance->byteIOIndex, partialBlock);
@@ -95,7 +95,7 @@ static void KangarooTwelve_F_Absorb(Opaque_KangarooTwelve_F *instance, const uns
     }
 }
 
-static void KangarooTwelve_F_AbsorbLastFewBits(Opaque_KangarooTwelve_F *instance, unsigned char delimitedData)
+static void KangarooTwelve_F_AbsorbLastFewBits(KangarooTwelve_F *instance, unsigned char delimitedData)
 {
     const unsigned int rateInBytes = K12_rateInBytes;
 
@@ -114,7 +114,7 @@ static void KangarooTwelve_F_AbsorbLastFewBits(Opaque_KangarooTwelve_F *instance
     instance->squeezing = 1;
 }
 
-static void KangarooTwelve_F_Squeeze(Opaque_KangarooTwelve_F *instance, unsigned char *data, size_t dataByteLen)
+static void KangarooTwelve_F_Squeeze(KangarooTwelve_F *instance, unsigned char *data, size_t dataByteLen)
 {
     size_t i, j;
     unsigned int partialBlock;
@@ -134,8 +134,7 @@ static void KangarooTwelve_F_Squeeze(Opaque_KangarooTwelve_F *instance, unsigned
                 curData+=rateInBytes;
             }
             i = dataByteLen - j;
-        }
-        else {
+        } else {
             /* normal lane: using the message queue */
             if (instance->byteIOIndex == rateInBytes) {
                 KeccakP1600_Permute_12rounds(instance->state);
@@ -163,50 +162,6 @@ typedef enum {
 } KCP_Phases;
 typedef KCP_Phases KangarooTwelve_Phases;
 
-typedef struct {
-    Opaque_KangarooTwelve_F queueNode;
-    Opaque_KangarooTwelve_F finalNode;
-    size_t fixedOutputLength;
-    size_t blockNumber;
-    size_t queueAbsorbedLen;
-    KangarooTwelve_Phases phase;
-} Opaque_KangarooTwelve_Instance;
-
-static void importF(Opaque_KangarooTwelve_F *internal_Instance, const KangarooTwelve_F *external_Instance)
-{
-    KeccakP1600_Initialize(internal_Instance->state);
-    KeccakP1600_AddBytes(internal_Instance->state, external_Instance->state, 0, 200);
-    internal_Instance->byteIOIndex = external_Instance->byteIOIndex;
-    internal_Instance->squeezing = external_Instance->squeezing;
-}
-
-static void exportF(KangarooTwelve_F *external_Instance, const Opaque_KangarooTwelve_F *internal_Instance)
-{
-    KeccakP1600_ExtractBytes(internal_Instance->state, external_Instance->state, 0, 200);
-    external_Instance->byteIOIndex = (uint8_t)internal_Instance->byteIOIndex;
-    external_Instance->squeezing = (uint8_t)internal_Instance->squeezing;
-}
-
-static void import(Opaque_KangarooTwelve_Instance *internal_Instance, const KangarooTwelve_Instance *external_Instance)
-{
-    importF(&internal_Instance->queueNode, &external_Instance->queueNode);
-    importF(&internal_Instance->finalNode, &external_Instance->finalNode);
-    internal_Instance->fixedOutputLength = external_Instance->fixedOutputLength;
-    internal_Instance->blockNumber = external_Instance->blockNumber;
-    internal_Instance->queueAbsorbedLen = external_Instance->queueAbsorbedLen;
-    internal_Instance->phase = (KangarooTwelve_Phases)external_Instance->phase;
-}
-
-static void export(KangarooTwelve_Instance *external_Instance, const Opaque_KangarooTwelve_Instance *internal_Instance)
-{
-    exportF(&external_Instance->queueNode, &internal_Instance->queueNode);
-    exportF(&external_Instance->finalNode, &internal_Instance->finalNode);
-    external_Instance->fixedOutputLength = internal_Instance->fixedOutputLength;
-    external_Instance->blockNumber = internal_Instance->blockNumber;
-    external_Instance->queueAbsorbedLen = internal_Instance->queueAbsorbedLen;
-    external_Instance->phase = (int)internal_Instance->phase;
-}
-
 #define K12_chunkSize       8192
 #define K12_suffixLeaf      0x0B /* '110': message hop, simple padding, inner node */
 
@@ -222,13 +177,13 @@ int KeccakP1600times2_IsAvailable()
 
 const char * KeccakP1600times2_GetImplementation()
 {
-    if (K12_enableAVX512)
+    if (K12_enableAVX512) {
         return "AVX-512 implementation";
-    else
-    if (K12_enableSSSE3)
+    } else if (K12_enableSSSE3) {
         return "SSSE3 implementation";
-    else
+    } else {
         return "";
+    }
 }
 
 void KangarooTwelve_SSSE3_Process2Leaves(const unsigned char *input, unsigned char *output);
@@ -236,11 +191,11 @@ void KangarooTwelve_AVX512_Process2Leaves(const unsigned char *input, unsigned c
 
 void KangarooTwelve_Process2Leaves(const unsigned char *input, unsigned char *output)
 {
-    if (K12_enableAVX512)
+    if (K12_enableAVX512) {
         KangarooTwelve_AVX512_Process2Leaves(input, output);
-    else
-    if (K12_enableSSSE3)
+    } else if (K12_enableSSSE3) {
         KangarooTwelve_SSSE3_Process2Leaves(input, output);
+    }
 }
 
 int KeccakP1600times4_IsAvailable()
@@ -253,13 +208,13 @@ int KeccakP1600times4_IsAvailable()
 
 const char * KeccakP1600times4_GetImplementation()
 {
-    if (K12_enableAVX512)
+    if (K12_enableAVX512) {
         return "AVX-512 implementation";
-    else
-    if (K12_enableAVX2)
+    } else if (K12_enableAVX2) {
         return "AVX2 implementation";
-    else
+    } else {
         return "";
+    }
 }
 
 void KangarooTwelve_AVX2_Process4Leaves(const unsigned char *input, unsigned char *output);
@@ -267,11 +222,11 @@ void KangarooTwelve_AVX512_Process4Leaves(const unsigned char *input, unsigned c
 
 void KangarooTwelve_Process4Leaves(const unsigned char *input, unsigned char *output)
 {
-    if (K12_enableAVX512)
+    if (K12_enableAVX512) {
         KangarooTwelve_AVX512_Process4Leaves(input, output);
-    else
-    if (K12_enableAVX2)
+    } else if (K12_enableAVX2) {
         KangarooTwelve_AVX2_Process4Leaves(input, output);
+    }
 }
 
 int KeccakP1600times8_IsAvailable()
@@ -283,10 +238,11 @@ int KeccakP1600times8_IsAvailable()
 
 const char * KeccakP1600times8_GetImplementation()
 {
-    if (K12_enableAVX512)
+    if (K12_enableAVX512) {
         return "AVX-512 implementation";
-    else
+    } else {
         return "";
+    }
 }
 
 void KangarooTwelve_AVX512_Process8Leaves(const unsigned char *input, unsigned char *output);
@@ -298,63 +254,56 @@ void KangarooTwelve_Process8Leaves(const unsigned char *input, unsigned char *ou
 }
 
 #define ProcessLeaves( Parallellism ) \
-    while ( inLen >= Parallellism * K12_chunkSize ) { \
+    while (inputByteLen >= Parallellism * K12_chunkSize) { \
         unsigned char intermediate[Parallellism*K12_capacityInBytes]; \
         \
         KangarooTwelve_Process##Parallellism##Leaves(input, intermediate); \
         input += Parallellism * K12_chunkSize; \
-        inLen -= Parallellism * K12_chunkSize; \
+        inputByteLen -= Parallellism * K12_chunkSize; \
         ktInstance->blockNumber += Parallellism; \
         KangarooTwelve_F_Absorb(&ktInstance->finalNode, intermediate, Parallellism * K12_capacityInBytes); \
     }
 
 #endif
 
-static unsigned int right_encode( unsigned char * encbuf, size_t value )
+static unsigned int right_encode(unsigned char * encbuf, size_t value)
 {
     unsigned int n, i;
     size_t v;
 
-    for ( v = value, n = 0; v && (n < sizeof(size_t)); ++n, v >>= 8 )
+    for (v = value, n = 0; v && (n < sizeof(size_t)); ++n, v >>= 8)
         ; /* empty */
-    for ( i = 1; i <= n; ++i )
+    for (i = 1; i <= n; ++i) {
         encbuf[i-1] = (unsigned char)(value >> (8 * (n-i)));
+    }
     encbuf[n] = (unsigned char)n;
     return n + 1;
 }
 
-static void K12_internal_Initialize(Opaque_KangarooTwelve_Instance *ktInstance, size_t outputLen)
+int KangarooTwelve_Initialize(KangarooTwelve_Instance *ktInstance, size_t outputByteLen)
 {
     KangarooTwelve_SetProcessorCapabilities();
-    ktInstance->fixedOutputLength = outputLen;
+    ktInstance->fixedOutputLength = outputByteLen;
     ktInstance->queueAbsorbedLen = 0;
     ktInstance->blockNumber = 0;
     ktInstance->phase = ABSORBING;
     KangarooTwelve_F_Initialize(&ktInstance->finalNode);
-}
-
-int KangarooTwelve_Initialize(KangarooTwelve_Instance *ktInstance, size_t outputByteLen)
-{
-    Opaque_KangarooTwelve_Instance internal;
-
-    K12_internal_Initialize(&internal, outputByteLen);
-    export(ktInstance, &internal);
     return 0;
 }
 
-static int K12_internal_Update(Opaque_KangarooTwelve_Instance *ktInstance, const unsigned char *input, size_t inLen)
+int KangarooTwelve_Update(KangarooTwelve_Instance *ktInstance, const unsigned char *input, size_t inputByteLen)
 {
     if (ktInstance->phase != ABSORBING)
         return 1;
 
-    if ( ktInstance->blockNumber == 0 ) {
+    if (ktInstance->blockNumber == 0) {
         /* First block, absorb in final node */
-        unsigned int len = (inLen < (K12_chunkSize - ktInstance->queueAbsorbedLen)) ? inLen : (K12_chunkSize - ktInstance->queueAbsorbedLen);
+        unsigned int len = (inputByteLen < (K12_chunkSize - ktInstance->queueAbsorbedLen)) ? inputByteLen : (K12_chunkSize - ktInstance->queueAbsorbedLen);
         KangarooTwelve_F_Absorb(&ktInstance->finalNode, input, len);
         input += len;
-        inLen -= len;
+        inputByteLen -= len;
         ktInstance->queueAbsorbedLen += len;
-        if ( (ktInstance->queueAbsorbedLen == K12_chunkSize) && (inLen != 0) ) {
+        if ((ktInstance->queueAbsorbedLen == K12_chunkSize) && (inputByteLen != 0)) {
             /* First block complete and more input data available, finalize it */
             const unsigned char padding = 0x03; /* '110^6': message hop, simple padding */
             ktInstance->queueAbsorbedLen = 0;
@@ -362,15 +311,14 @@ static int K12_internal_Update(Opaque_KangarooTwelve_Instance *ktInstance, const
             KangarooTwelve_F_Absorb(&ktInstance->finalNode, &padding, 1);
             ktInstance->finalNode.byteIOIndex = (ktInstance->finalNode.byteIOIndex + 7) & ~7; /* Zero padding up to 64 bits */
         }
-    }
-    else if ( ktInstance->queueAbsorbedLen != 0 ) {
+    } else if (ktInstance->queueAbsorbedLen != 0) {
         /* There is data in the queue, absorb further in queue until block complete */
-        unsigned int len = (inLen < (K12_chunkSize - ktInstance->queueAbsorbedLen)) ? inLen : (K12_chunkSize - ktInstance->queueAbsorbedLen);
+        unsigned int len = (inputByteLen < (K12_chunkSize - ktInstance->queueAbsorbedLen)) ? inputByteLen : (K12_chunkSize - ktInstance->queueAbsorbedLen);
         KangarooTwelve_F_Absorb(&ktInstance->queueNode, input, len);
         input += len;
-        inLen -= len;
+        inputByteLen -= len;
         ktInstance->queueAbsorbedLen += len;
-        if ( ktInstance->queueAbsorbedLen == K12_chunkSize ) {
+        if (ktInstance->queueAbsorbedLen == K12_chunkSize) {
             unsigned char intermediate[K12_capacityInBytes];
             ktInstance->queueAbsorbedLen = 0;
             ++ktInstance->blockNumber;
@@ -394,38 +342,27 @@ static int K12_internal_Update(Opaque_KangarooTwelve_Instance *ktInstance, const
     }
 #endif
 
-    while ( inLen > 0 ) {
-        unsigned int len = (inLen < K12_chunkSize) ? inLen : K12_chunkSize;
+    while (inputByteLen > 0) {
+        unsigned int len = (inputByteLen < K12_chunkSize) ? inputByteLen : K12_chunkSize;
         KangarooTwelve_F_Initialize(&ktInstance->queueNode);
         KangarooTwelve_F_Absorb(&ktInstance->queueNode, input, len);
         input += len;
-        inLen -= len;
-        if ( len == K12_chunkSize ) {
+        inputByteLen -= len;
+        if (len == K12_chunkSize) {
             unsigned char intermediate[K12_capacityInBytes];
             ++ktInstance->blockNumber;
             KangarooTwelve_F_AbsorbLastFewBits(&ktInstance->queueNode, K12_suffixLeaf);
             KangarooTwelve_F_Squeeze(&ktInstance->queueNode, intermediate, K12_capacityInBytes);
             KangarooTwelve_F_Absorb(&ktInstance->finalNode, intermediate, K12_capacityInBytes);
-        }
-        else
+        } else {
             ktInstance->queueAbsorbedLen = len;
+        }
     }
 
     return 0;
 }
 
-int KangarooTwelve_Update(KangarooTwelve_Instance *ktInstance, const unsigned char *input, size_t inputByteLen)
-{
-    Opaque_KangarooTwelve_Instance internal;
-    int result;
-
-    import(&internal, ktInstance);
-    result = K12_internal_Update(&internal, input, inputByteLen);
-    export(ktInstance, &internal);
-    return result;
-}
-
-static int K12_internal_Final(Opaque_KangarooTwelve_Instance *ktInstance, unsigned char * output, const unsigned char * customization, size_t customLen)
+int KangarooTwelve_Final(KangarooTwelve_Instance *ktInstance, unsigned char *output, const unsigned char *customization, size_t customByteLen)
 {
     unsigned char encbuf[sizeof(size_t)+1+2];
     unsigned char padding;
@@ -433,20 +370,19 @@ static int K12_internal_Final(Opaque_KangarooTwelve_Instance *ktInstance, unsign
     if (ktInstance->phase != ABSORBING)
         return 1;
 
-    /* Absorb customization | right_encode(customLen) */
-    if ((customLen != 0) && (K12_internal_Update(ktInstance, customization, customLen) != 0))
+    /* Absorb customization | right_encode(customByteLen) */
+    if ((customByteLen != 0) && (KangarooTwelve_Update(ktInstance, customization, customByteLen) != 0))
         return 1;
-    if (K12_internal_Update(ktInstance, encbuf, right_encode(encbuf, customLen)) != 0)
+    if (KangarooTwelve_Update(ktInstance, encbuf, right_encode(encbuf, customByteLen)) != 0)
         return 1;
 
-    if ( ktInstance->blockNumber == 0 ) {
+    if (ktInstance->blockNumber == 0) {
         /* Non complete first block in final node, pad it */
         padding = 0x07; /*  '11': message hop, final node */
-    }
-    else {
+    } else {
         unsigned int n;
 
-        if ( ktInstance->queueAbsorbedLen != 0 ) {
+        if (ktInstance->queueAbsorbedLen != 0) {
             /* There is data in the queue node */
             unsigned char intermediate[K12_capacityInBytes];
             ++ktInstance->blockNumber;
@@ -462,7 +398,7 @@ static int K12_internal_Final(Opaque_KangarooTwelve_Instance *ktInstance, unsign
         padding = 0x06; /* '01': chaining hop, final node */
     }
     KangarooTwelve_F_AbsorbLastFewBits(&ktInstance->finalNode, padding);
-    if ( ktInstance->fixedOutputLength != 0 ) {
+    if (ktInstance->fixedOutputLength != 0) {
         ktInstance->phase = FINAL;
         KangarooTwelve_F_Squeeze(&ktInstance->finalNode, output, ktInstance->fixedOutputLength);
         return 0;
@@ -471,46 +407,26 @@ static int K12_internal_Final(Opaque_KangarooTwelve_Instance *ktInstance, unsign
     return 0;
 }
 
-int KangarooTwelve_Final(KangarooTwelve_Instance *ktInstance, unsigned char *output, const unsigned char *customization, size_t customByteLen)
-{
-    Opaque_KangarooTwelve_Instance internal;
-    int result;
-
-    import(&internal, ktInstance);
-    result = K12_internal_Final(&internal, output, customization, customByteLen);
-    export(ktInstance, &internal);
-    return result;
-}
-
-static int K12_internal_Squeeze(Opaque_KangarooTwelve_Instance *ktInstance, unsigned char * output, size_t outputLen)
+int KangarooTwelve_Squeeze(KangarooTwelve_Instance *ktInstance, unsigned char *output, size_t outputByteLen)
 {
     if (ktInstance->phase != SQUEEZING)
         return 1;
-    KangarooTwelve_F_Squeeze(&ktInstance->finalNode, output, outputLen);
+    KangarooTwelve_F_Squeeze(&ktInstance->finalNode, output, outputByteLen);
     return 0;
 }
 
-int KangarooTwelve_Squeeze(KangarooTwelve_Instance *ktInstance, unsigned char *output, size_t outputByteLen)
+int KangarooTwelve(const unsigned char *input, size_t inputByteLen,
+                   unsigned char *output, size_t outputByteLen,
+                   const unsigned char *customization, size_t customByteLen)
 {
-    Opaque_KangarooTwelve_Instance internal;
-    int result;
+    KangarooTwelve_Instance ktInstance;
 
-    import(&internal, ktInstance);
-    result = K12_internal_Squeeze(&internal, output, outputByteLen);
-    export(ktInstance, &internal);
-    return result;
-}
-
-int KangarooTwelve( const unsigned char * input, size_t inLen, unsigned char * output, size_t outLen, const unsigned char * customization, size_t customLen )
-{
-    Opaque_KangarooTwelve_Instance ktInstance;
-
-    if (outLen == 0)
+    if (outputByteLen == 0)
         return 1;
-    K12_internal_Initialize(&ktInstance, outLen);
-    if (K12_internal_Update(&ktInstance, input, inLen) != 0)
+    KangarooTwelve_Initialize(&ktInstance, outputByteLen);
+    if (KangarooTwelve_Update(&ktInstance, input, inputByteLen) != 0)
         return 1;
-    return K12_internal_Final(&ktInstance, output, customization, customLen);
+    return KangarooTwelve_Final(&ktInstance, output, customization, customByteLen);
 }
 
 /* ---------------------------------------------------------------- */
@@ -643,12 +559,17 @@ static enum cpu_feature
 void KangarooTwelve_SetProcessorCapabilities(void)
 {
     enum cpu_feature features = get_cpu_features();
-    K12_enableSSSE3 = (features & SSSE3) && !K12_SSSE3_requested_disabled;
-    K12_enableAVX2 = (features & AVX2) && !K12_AVX2_requested_disabled;
-    K12_enableAVX512 = (features & AVX512F) && (features & AVX512VL) && !K12_AVX512_requested_disabled;
+    K12_enableSSSE3 = (features & SSSE3);
+    K12_enableAVX2 = (features & AVX2);
+    K12_enableAVX512 = (features & AVX512F) && (features & AVX512VL);
+#ifdef KeccakP1600_enable_simd_options
+    K12_enableSSSE3 = K12_enableSSSE3 && !K12_SSSE3_requested_disabled;
+    K12_enableAVX2 = K12_enableAVX2 && !K12_AVX2_requested_disabled;
+    K12_enableAVX512 = K12_enableAVX512 && !K12_AVX512_requested_disabled;
+#endif  // KeccakP1600_enable_simd_options
 }
 
-#ifndef KeccakP1600_disableParallelism
+#ifdef KeccakP1600_enable_simd_options
 int KangarooTwelve_DisableSSSE3(void) {
     KangarooTwelve_SetProcessorCapabilities();
     K12_SSSE3_requested_disabled = 1;
@@ -688,4 +609,4 @@ void KangarooTwelve_EnableAllCpuFeatures(void) {
     K12_AVX512_requested_disabled = 0;
     KangarooTwelve_SetProcessorCapabilities();
 }
-#endif  // KeccakP1600_disableParallelism
+#endif  // KeccakP1600_enable_simd_options

--- a/tests/testKangarooTwelve.c
+++ b/tests/testKangarooTwelve.c
@@ -72,14 +72,14 @@ static void performTestKangarooTwelveOneInput(unsigned int inputLen, unsigned in
     generateSimpleRawMaterial(input, inputLen, outputLen, inputLen + customLen);
 
     #ifdef VERBOSE
-    printf( "outputLen %5u, inputLen %5u, customLen %3u\n", outputLen, inputLen, customLen);
+    printf("outputLen %5u, inputLen %5u, customLen %3u\n", outputLen, inputLen, customLen);
     #endif
     if (!useSqueeze)
     {
         if (mode == 0)
         {
             /* Input/Output full size in one call */
-            result = KangarooTwelve( input, inputLen, output, outputLen, customization, customLen );
+            result = KangarooTwelve(input, inputLen, output, outputLen, customization, customLen);
             assert(result == 0);
         }
         else if (mode == 1)
@@ -88,12 +88,12 @@ static void performTestKangarooTwelveOneInput(unsigned int inputLen, unsigned in
             KangarooTwelve_Instance kt;
             result = KangarooTwelve_Initialize(&kt, outputLen);
             assert(result == 0);
-            for (i = 0; i < inputLen; ++i )
+            for (i = 0; i < inputLen; ++i)
             {
                 result = KangarooTwelve_Update(&kt, input + i, 1);
                 assert(result == 0);
             }
-            result =  KangarooTwelve_Final(&kt, output, customization, customLen );
+            result = KangarooTwelve_Final(&kt, output, customization, customLen);
             assert(result == 0);
         }
         else if (mode == 2)
@@ -111,7 +111,7 @@ static void performTestKangarooTwelveOneInput(unsigned int inputLen, unsigned in
                 pInput += len;
                 inputLen -= len;
             }
-            result =  KangarooTwelve_Final(&kt, output, customization, customLen);
+            result = KangarooTwelve_Final(&kt, output, customization, customLen);
             assert(result == 0);
         }
     }
@@ -141,7 +141,7 @@ static void performTestKangarooTwelveOneInput(unsigned int inputLen, unsigned in
 
             for (i = 0; i < outputLen; ++i)
             {
-                result =  KangarooTwelve_Squeeze(&kt, output + i, 1);
+                result = KangarooTwelve_Squeeze(&kt, output + i, 1);
                 assert(result == 0);
             }
         }
@@ -217,7 +217,7 @@ static void performTestKangarooTwelve(unsigned char *checksum, unsigned int mode
     #ifdef VERBOSE
     {
         unsigned int i;
-        printf("KangarooTwelve\n" );
+        printf("KangarooTwelve\n");
         printf("Checksum: ");
         for(i=0; i<checksumByteSize; i++)
             printf("\\x%02x", (int)checksum[i]);
@@ -328,36 +328,6 @@ void printKangarooTwelveTestVectors()
     }
 }
 
-#ifndef KeccakP1600_disableParallelism
-void testKangarooTwelveWithChangingCpuFeatures()
-{
-    uint8_t M[289];
-    uint8_t output[32];
-    const size_t l = 289;
-    const uint8_t expected[32] = {
-        0x0c, 0x31, 0x5e, 0xbc, 0xde, 0xdb, 0xf6, 0x14, 0x26, 0xde, 0x7d, 0xcf, 0x8f, 0xb7, 0x25, 0xd1,
-        0xe7, 0x46, 0x75, 0xd7, 0xf5, 0x32, 0x7a, 0x50, 0x67, 0xf3, 0x67, 0xb1, 0x08, 0xec, 0xb6, 0x7c };
-    KangarooTwelve_Instance k12;
-
-    printf("\n * Testing KangarooTwelve interleaved with changing CPU features\n");
-    for(size_t j=0; j<l; j++)
-        M[j] = j%251;
-    KangarooTwelve_Initialize(&k12, 32);
-    for(size_t j=0; j<l; j++) {
-        // Pseudo-randomly switch on/off the CPU features
-        uint8_t features = expected[j % 32] ^ M[j];
-        KangarooTwelve_EnableAllCpuFeatures();
-        if (features & 1) KangarooTwelve_DisableAVX512();
-        if (features & 2) KangarooTwelve_DisableAVX2();
-        if (features & 4) KangarooTwelve_DisableSSSE3();
-        KangarooTwelve_Update(&k12, &M[j], 1);
-    }
-    KangarooTwelve_Final(&k12, output, "", 0);
-    assert(memcmp(expected, output, 32) == 0);
-    printf("   - OK\n");
-}
-#endif
-
 void testKangarooTwelve(void)
 {
 #ifdef OUTPUT
@@ -399,8 +369,5 @@ void testKangarooTwelve(void)
         KangarooTwelve_EnableAllCpuFeatures();
         selfTestKangarooTwelve();
     }
-
-    // Test with changing features
-    testKangarooTwelveWithChangingCpuFeatures();
 #endif
 }


### PR DESCRIPTION
Here is my argument:

These options are almost definitely not useful to toggle around at run-time. Doing so is kind of silly; the only conceivable use for this would be to eke out a tiny amount of performance.  Adapting the API to copy the entire state struct out and reorder its incoming bytes every operation, while it solves the state incompatibility, also *significantly* injures performance -- far more than any use of the options in this way could ever remedy, and it does so even if you're not using them. With the changes introduced in commit b1200095, run-time of the old (slightly longer) K12 self-check suite nearly quadrupled. (I've confirmed that these changes fix that regression.)

The main, or indeed *only* known real utility of these options at present is to increase testability: every code path that can run on your processor does in the test suite, so if you break something in non-AVX512 architectures you can find out without commenting out any code. (The comparison in the performance test is also very handy.)

I would honestly rather delete all these options and put the functionality *only in the test suite* than see this performance regression stay in master, if it's that much of an issue that these APIs can be abused to obtain wrong results from a hash instance by changing implementation halfway through. So, I've gatekept the symbols and functionality behind not only sterner warnings but a compile-time macro condition as well. It's not super hard to enable, but it's involved enough that you would almost surely find out how it shouldn't be used if you made such mistakes possible.

I also experimented with buildfile options to make a library version that exposes these functions, but I wasn't satisfied with how it looked; I'm sure the owners have a better idea of what that would ideally look like.