### PR TITLE
Implement plain64 build

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -37,6 +37,7 @@ http://creativecommons.org/publicdomain/zero/1.0/
         <c gcc="-mssse3">lib/Optimized64/KeccakP-1600-timesN-SSSE3.c</c>
         <c gcc="-mavx2">lib/Optimized64/KeccakP-1600-timesN-AVX2.c</c>
         <c gcc="-mavx512f -mavx512vl">lib/Optimized64/KeccakP-1600-timesN-AVX512.c</c>
+        <c>lib/Optimized64/KeccakP-1600-runtimeDispatch.c</c>
     </fragment>
 
     <fragment name="optimized64noAsm" inherits="optimized">
@@ -46,7 +47,14 @@ http://creativecommons.org/publicdomain/zero/1.0/
         <c gcc="-mssse3">lib/Optimized64/KeccakP-1600-timesN-SSSE3.c</c>
         <c gcc="-mavx2">lib/Optimized64/KeccakP-1600-timesN-AVX2.c</c>
         <c gcc="-mavx512f -mavx512vl">lib/Optimized64/KeccakP-1600-timesN-AVX512.c</c>
+        <c>lib/Optimized64/KeccakP-1600-runtimeDispatch.c</c>
         <define>KeccakP1600_noAssembly</define>
+    </fragment>
+
+    <fragment name="optimized64plain" inherits="optimized">
+        <c>lib/Optimized64/KeccakP-1600-opt64.c</c>
+        <c>lib/Plain64/KeccakP-1600-plain64.c</c>
+        <h>lib/Plain64/KeccakP-1600-SnP.h</h>
     </fragment>
 
     <!-- KangarooTwelve -->
@@ -88,10 +96,13 @@ http://creativecommons.org/publicdomain/zero/1.0/
     <!-- Same, but without the assembly file (for MS Visual Studio) -->
     <fragment name="generic64noAsm" inherits="optimized64noAsm"/>
 
+    <!-- Plain C optimized 64-bit implementation only -->
+    <fragment name="plain64" inherits="optimized64plain"/>
+
     <!-- Target names are of the form x/y where x is taken from the first set and y from the second set. -->
     <group all="all">
         <product delimiter="/">
-            <factor set="generic32 generic64 generic64noAsm"/>
+            <factor set="generic32 generic64 generic64noAsm plain64"/>
             <factor set="K12Tests libk12.a libk12.so libk12.dylib"/>
         </product>
     </group>

--- a/lib/Inplace32BI/KeccakP-1600-inplace32BI.c
+++ b/lib/Inplace32BI/KeccakP-1600-inplace32BI.c
@@ -168,7 +168,7 @@ void KeccakP1600_AddBytesInLane(void *state, unsigned int lanePosition, const un
 
 /* ---------------------------------------------------------------- */
 
-void KeccakP1600_AddLanes(void *state, const unsigned char *data, unsigned int laneCount)
+static void KeccakP1600_AddLanes(void *state, const unsigned char *data, unsigned int laneCount)
 {
 #if (PLATFORM_BYTE_ORDER == IS_LITTLE_ENDIAN)
     const uint32_t * pI = (const uint32_t *)data;

--- a/lib/KangarooTwelve.c
+++ b/lib/KangarooTwelve.c
@@ -16,23 +16,8 @@ http://creativecommons.org/publicdomain/zero/1.0/
 
 #include <assert.h>
 #include <string.h>
-#include "align.h"
 #include "KangarooTwelve.h"
 #include "KeccakP-1600-SnP.h"
-
-#ifdef KeccakP1600_disableParallelism
-#undef KeccakP1600_enable_simd_options
-#endif  // KeccakP1600_disableParallelism
-
-void KangarooTwelve_SetProcessorCapabilities(void);
-#ifdef KeccakP1600_enable_simd_options
-int K12_SSSE3_requested_disabled = 0;
-int K12_AVX2_requested_disabled = 0;
-int K12_AVX512_requested_disabled = 0;
-#endif  // KeccakP1600_enable_simd_options
-int K12_enableSSSE3 = 0;
-int K12_enableAVX2 = 0;
-int K12_enableAVX512 = 0;
 
 /* ---------------------------------------------------------------- */
 
@@ -167,91 +152,9 @@ typedef KCP_Phases KangarooTwelve_Phases;
 
 #ifndef KeccakP1600_disableParallelism
 
-int KeccakP1600times2_IsAvailable()
-{
-    int result = 0;
-    result |= K12_enableAVX512;
-    result |= K12_enableSSSE3;
-    return result;
-}
-
-const char * KeccakP1600times2_GetImplementation()
-{
-    if (K12_enableAVX512) {
-        return "AVX-512 implementation";
-    } else if (K12_enableSSSE3) {
-        return "SSSE3 implementation";
-    } else {
-        return "";
-    }
-}
-
-void KangarooTwelve_SSSE3_Process2Leaves(const unsigned char *input, unsigned char *output);
-void KangarooTwelve_AVX512_Process2Leaves(const unsigned char *input, unsigned char *output);
-
-void KangarooTwelve_Process2Leaves(const unsigned char *input, unsigned char *output)
-{
-    if (K12_enableAVX512) {
-        KangarooTwelve_AVX512_Process2Leaves(input, output);
-    } else if (K12_enableSSSE3) {
-        KangarooTwelve_SSSE3_Process2Leaves(input, output);
-    }
-}
-
-int KeccakP1600times4_IsAvailable()
-{
-    int result = 0;
-    result |= K12_enableAVX512;
-    result |= K12_enableAVX2;
-    return result;
-}
-
-const char * KeccakP1600times4_GetImplementation()
-{
-    if (K12_enableAVX512) {
-        return "AVX-512 implementation";
-    } else if (K12_enableAVX2) {
-        return "AVX2 implementation";
-    } else {
-        return "";
-    }
-}
-
-void KangarooTwelve_AVX2_Process4Leaves(const unsigned char *input, unsigned char *output);
-void KangarooTwelve_AVX512_Process4Leaves(const unsigned char *input, unsigned char *output);
-
-void KangarooTwelve_Process4Leaves(const unsigned char *input, unsigned char *output)
-{
-    if (K12_enableAVX512) {
-        KangarooTwelve_AVX512_Process4Leaves(input, output);
-    } else if (K12_enableAVX2) {
-        KangarooTwelve_AVX2_Process4Leaves(input, output);
-    }
-}
-
-int KeccakP1600times8_IsAvailable()
-{
-    int result = 0;
-    result |= K12_enableAVX512;
-    return result;
-}
-
-const char * KeccakP1600times8_GetImplementation()
-{
-    if (K12_enableAVX512) {
-        return "AVX-512 implementation";
-    } else {
-        return "";
-    }
-}
-
-void KangarooTwelve_AVX512_Process8Leaves(const unsigned char *input, unsigned char *output);
-
-void KangarooTwelve_Process8Leaves(const unsigned char *input, unsigned char *output)
-{
-    if (K12_enableAVX512)
-        KangarooTwelve_AVX512_Process8Leaves(input, output);
-}
+void KangarooTwelve_Process2Leaves(const unsigned char *input, unsigned char *output);
+void KangarooTwelve_Process4Leaves(const unsigned char *input, unsigned char *output);
+void KangarooTwelve_Process8Leaves(const unsigned char *input, unsigned char *output);
 
 #define ProcessLeaves( Parallellism ) \
     while (inputByteLen >= Parallellism * K12_chunkSize) { \
@@ -264,7 +167,7 @@ void KangarooTwelve_Process8Leaves(const unsigned char *input, unsigned char *ou
         KangarooTwelve_F_Absorb(&ktInstance->finalNode, intermediate, Parallellism * K12_capacityInBytes); \
     }
 
-#endif
+#endif  // KeccakP1600_disableParallelism
 
 static unsigned int right_encode(unsigned char * encbuf, size_t value)
 {
@@ -282,7 +185,6 @@ static unsigned int right_encode(unsigned char * encbuf, size_t value)
 
 int KangarooTwelve_Initialize(KangarooTwelve_Instance *ktInstance, size_t outputByteLen)
 {
-    KangarooTwelve_SetProcessorCapabilities();
     ktInstance->fixedOutputLength = outputByteLen;
     ktInstance->queueAbsorbedLen = 0;
     ktInstance->blockNumber = 0;
@@ -428,185 +330,3 @@ int KangarooTwelve(const unsigned char *input, size_t inputByteLen,
         return 1;
     return KangarooTwelve_Final(&ktInstance, output, customization, customByteLen);
 }
-
-/* ---------------------------------------------------------------- */
-
-/* Processor capability detection code by Samuel Neves and Jack O'Connor, see
- * https://github.com/BLAKE3-team/BLAKE3/blob/master/c/blake3_dispatch.c
- */
-
-#if defined(__x86_64__) || defined(_M_X64)
-#define IS_X86
-#define IS_X86_64
-#endif
-
-#if defined(__i386__) || defined(_M_IX86)
-#define IS_X86
-#define IS_X86_32
-#endif
-
-#if defined(IS_X86)
-static uint64_t xgetbv() {
-#if defined(_MSC_VER)
-  return _xgetbv(0);
-#else
-  uint32_t eax = 0, edx = 0;
-  __asm__ __volatile__("xgetbv\n" : "=a"(eax), "=d"(edx) : "c"(0));
-  return ((uint64_t)edx << 32) | eax;
-#endif
-}
-
-static void cpuid(uint32_t out[4], uint32_t id) {
-#if defined(_MSC_VER)
-  __cpuid((int *)out, id);
-#elif defined(__i386__) || defined(_M_IX86)
-  __asm__ __volatile__("movl %%ebx, %1\n"
-                       "cpuid\n"
-                       "xchgl %1, %%ebx\n"
-                       : "=a"(out[0]), "=r"(out[1]), "=c"(out[2]), "=d"(out[3])
-                       : "a"(id));
-#else
-  __asm__ __volatile__("cpuid\n"
-                       : "=a"(out[0]), "=b"(out[1]), "=c"(out[2]), "=d"(out[3])
-                       : "a"(id));
-#endif
-}
-
-static void cpuidex(uint32_t out[4], uint32_t id, uint32_t sid) {
-#if defined(_MSC_VER)
-  __cpuidex((int *)out, id, sid);
-#elif defined(__i386__) || defined(_M_IX86)
-  __asm__ __volatile__("movl %%ebx, %1\n"
-                       "cpuid\n"
-                       "xchgl %1, %%ebx\n"
-                       : "=a"(out[0]), "=r"(out[1]), "=c"(out[2]), "=d"(out[3])
-                       : "a"(id), "c"(sid));
-#else
-  __asm__ __volatile__("cpuid\n"
-                       : "=a"(out[0]), "=b"(out[1]), "=c"(out[2]), "=d"(out[3])
-                       : "a"(id), "c"(sid));
-#endif
-}
-
-#endif
-
-enum cpu_feature {
-  SSE2 = 1 << 0,
-  SSSE3 = 1 << 1,
-  SSE41 = 1 << 2,
-  AVX = 1 << 3,
-  AVX2 = 1 << 4,
-  AVX512F = 1 << 5,
-  AVX512VL = 1 << 6,
-  /* ... */
-  UNDEFINED = 1 << 30
-};
-
-static enum cpu_feature g_cpu_features = UNDEFINED;
-
-static enum cpu_feature
-    get_cpu_features(void) {
-
-  if (g_cpu_features != UNDEFINED) {
-    return g_cpu_features;
-  } else {
-#if defined(IS_X86)
-    uint32_t regs[4] = {0};
-    uint32_t *eax = &regs[0], *ebx = &regs[1], *ecx = &regs[2], *edx = &regs[3];
-    (void)edx;
-    enum cpu_feature features = 0;
-    cpuid(regs, 0);
-    const int max_id = *eax;
-    cpuid(regs, 1);
-#if defined(__amd64__) || defined(_M_X64)
-    features |= SSE2;
-#else
-    if (*edx & (1UL << 26))
-      features |= SSE2;
-#endif
-    if (*ecx & (1UL << 0))
-      features |= SSSE3;
-    if (*ecx & (1UL << 19))
-      features |= SSE41;
-
-    if (*ecx & (1UL << 27)) { // OSXSAVE
-      const uint64_t mask = xgetbv();
-      if ((mask & 6) == 6) { // SSE and AVX states
-        if (*ecx & (1UL << 28))
-          features |= AVX;
-        if (max_id >= 7) {
-          cpuidex(regs, 7, 0);
-          if (*ebx & (1UL << 5))
-            features |= AVX2;
-          if ((mask & 224) == 224) { // Opmask, ZMM_Hi256, Hi16_Zmm
-            if (*ebx & (1UL << 31))
-              features |= AVX512VL;
-            if (*ebx & (1UL << 16))
-              features |= AVX512F;
-          }
-        }
-      }
-    }
-    g_cpu_features = features;
-    return features;
-#else
-    /* How to detect NEON? */
-    return 0;
-#endif
-  }
-}
-
-void KangarooTwelve_SetProcessorCapabilities(void)
-{
-    enum cpu_feature features = get_cpu_features();
-    K12_enableSSSE3 = (features & SSSE3);
-    K12_enableAVX2 = (features & AVX2);
-    K12_enableAVX512 = (features & AVX512F) && (features & AVX512VL);
-#ifdef KeccakP1600_enable_simd_options
-    K12_enableSSSE3 = K12_enableSSSE3 && !K12_SSSE3_requested_disabled;
-    K12_enableAVX2 = K12_enableAVX2 && !K12_AVX2_requested_disabled;
-    K12_enableAVX512 = K12_enableAVX512 && !K12_AVX512_requested_disabled;
-#endif  // KeccakP1600_enable_simd_options
-}
-
-#ifdef KeccakP1600_enable_simd_options
-int KangarooTwelve_DisableSSSE3(void) {
-    KangarooTwelve_SetProcessorCapabilities();
-    K12_SSSE3_requested_disabled = 1;
-    if (K12_enableSSSE3) {
-        KangarooTwelve_SetProcessorCapabilities();
-        return 1;  // SSSE3 was disabled on this call.
-    } else {
-        return 0;  // Nothing changed.
-    }
-}
-
-int KangarooTwelve_DisableAVX2(void) {
-    KangarooTwelve_SetProcessorCapabilities();
-    K12_AVX2_requested_disabled = 1;
-    if (K12_enableAVX2) {
-        KangarooTwelve_SetProcessorCapabilities();
-        return 1;  // AVX2 was disabled on this call.
-    } else {
-        return 0;  // Nothing changed.
-    }
-}
-
-int KangarooTwelve_DisableAVX512(void) {
-    KangarooTwelve_SetProcessorCapabilities();
-    K12_AVX512_requested_disabled = 1;
-    if (K12_enableAVX512) {
-        KangarooTwelve_SetProcessorCapabilities();
-        return 1;  // AVX512 was disabled on this call.
-    } else {
-        return 0;  // Nothing changed.
-    }
-}
-
-void KangarooTwelve_EnableAllCpuFeatures(void) {
-    K12_SSSE3_requested_disabled = 0;
-    K12_AVX2_requested_disabled = 0;
-    K12_AVX512_requested_disabled = 0;
-    KangarooTwelve_SetProcessorCapabilities();
-}
-#endif  // KeccakP1600_enable_simd_options

--- a/lib/Optimized64/KeccakP-1600-opt64.c
+++ b/lib/Optimized64/KeccakP-1600-opt64.c
@@ -22,101 +22,7 @@ Please refer to the XKCP for more details.
 #include <stdlib.h>
 #include <string.h>
 #include "brg_endian.h"
-#include "KeccakP-1600-SnP.h"
-
-extern int K12_enableAVX2;
-extern int K12_enableAVX512;
-
-const char * KeccakP1600_GetImplementation()
-{
-    if (K12_enableAVX512)
-        return "AVX-512 implementation";
-    else
-#ifndef KeccakP1600_noAssembly
-    if (K12_enableAVX2)
-        return "AVX2 implementation";
-    else
-#endif
-        return "generic 64-bit implementation";
-}
-
-void KeccakP1600_Initialize(void *state)
-{
-    if (K12_enableAVX512)
-        KeccakP1600_AVX512_Initialize(state);
-    else
-#ifndef KeccakP1600_noAssembly
-    if (K12_enableAVX2)
-        KeccakP1600_AVX2_Initialize(state);
-    else
-#endif
-        KeccakP1600_opt64_Initialize(state);
-}
-
-void KeccakP1600_AddByte(void *state, unsigned char data, unsigned int offset)
-{
-    if (K12_enableAVX512)
-        ((unsigned char*)(state))[offset] ^= data;
-    else
-#ifndef KeccakP1600_noAssembly
-    if (K12_enableAVX2)
-        KeccakP1600_AVX2_AddByte(state, data, offset);
-    else
-#endif
-        KeccakP1600_opt64_AddByte(state, data, offset);
-}
-
-void KeccakP1600_AddBytes(void *state, const unsigned char *data, unsigned int offset, unsigned int length)
-{
-    if (K12_enableAVX512)
-        KeccakP1600_AVX512_AddBytes(state, data, offset, length);
-    else
-#ifndef KeccakP1600_noAssembly
-    if (K12_enableAVX2)
-        KeccakP1600_AVX2_AddBytes(state, data, offset, length);
-    else
-#endif
-        KeccakP1600_opt64_AddBytes(state, data, offset, length);
-}
-
-void KeccakP1600_Permute_12rounds(void *state)
-{
-    if (K12_enableAVX512)
-        KeccakP1600_AVX512_Permute_12rounds(state);
-    else
-#ifndef KeccakP1600_noAssembly
-    if (K12_enableAVX2)
-        KeccakP1600_AVX2_Permute_12rounds(state);
-    else
-#endif
-        KeccakP1600_opt64_Permute_12rounds(state);
-}
-
-void KeccakP1600_ExtractBytes(const void *state, unsigned char *data, unsigned int offset, unsigned int length)
-{
-    if (K12_enableAVX512)
-        KeccakP1600_AVX512_ExtractBytes(state, data, offset, length);
-    else
-#ifndef KeccakP1600_noAssembly
-    if (K12_enableAVX2)
-        KeccakP1600_AVX2_ExtractBytes(state, data, offset, length);
-    else
-#endif
-        KeccakP1600_opt64_ExtractBytes(state, data, offset, length);
-}
-
-size_t KeccakP1600_12rounds_FastLoop_Absorb(void *state, unsigned int laneCount, const unsigned char *data, size_t dataByteLen)
-{
-    if (K12_enableAVX512)
-        return KeccakP1600_AVX512_12rounds_FastLoop_Absorb(state, laneCount, data, dataByteLen);
-    else
-#ifndef KeccakP1600_noAssembly
-    if (K12_enableAVX2)
-        return KeccakP1600_AVX2_12rounds_FastLoop_Absorb(state, laneCount, data, dataByteLen);
-    else
-#endif
-        return KeccakP1600_opt64_12rounds_FastLoop_Absorb(state, laneCount, data, dataByteLen);
-}
+#include <KeccakP-1600-SnP.h>
 
 #define KeccakP1600_opt64_implementation_config "all rounds unrolled"
 #define KeccakP1600_opt64_fullUnrolling
@@ -235,7 +141,7 @@ void KeccakP1600_opt64_AddBytesInLane(void *state, unsigned int lanePosition, co
 
 /* ---------------------------------------------------------------- */
 
-void KeccakP1600_opt64_AddLanes(void *state, const unsigned char *data, unsigned int laneCount)
+static void KeccakP1600_opt64_AddLanes(void *state, const unsigned char *data, unsigned int laneCount)
 {
 #if (PLATFORM_BYTE_ORDER == IS_LITTLE_ENDIAN)
     unsigned int i = 0;

--- a/lib/Optimized64/KeccakP-1600-runtimeDispatch.c
+++ b/lib/Optimized64/KeccakP-1600-runtimeDispatch.c
@@ -1,0 +1,406 @@
+/*
+K12 based on the eXtended Keccak Code Package (XKCP)
+https://github.com/XKCP/XKCP
+
+The Keccak-p permutations, designed by Guido Bertoni, Joan Daemen, Michaël Peeters and Gilles Van Assche.
+
+Implementation by Gilles Van Assche and Ronny Van Keer, hereby denoted as "the implementer".
+
+For more information, feedback or questions, please refer to the Keccak Team website:
+https://keccak.team/
+
+To the extent possible under law, the implementer has waived all copyright
+and related or neighboring rights to the source code in this file.
+http://creativecommons.org/publicdomain/zero/1.0/
+
+---
+
+Please refer to the XKCP for more details.
+*/
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include "brg_endian.h"
+#include "KeccakP-1600-SnP.h"
+
+#ifdef KeccakP1600_disableParallelism
+#undef KeccakP1600_enable_simd_options
+#else
+
+// Forward declaration
+void KangarooTwelve_SetProcessorCapabilities();
+#ifdef KeccakP1600_enable_simd_options
+int K12_SSSE3_requested_disabled = 0;
+int K12_AVX2_requested_disabled = 0;
+int K12_AVX512_requested_disabled = 0;
+#endif  // KeccakP1600_enable_simd_options
+int K12_enableSSSE3 = 0;
+int K12_enableAVX2 = 0;
+int K12_enableAVX512 = 0;
+
+/* ---------------------------------------------------------------- */
+
+void KangarooTwelve_SSSE3_Process2Leaves(const unsigned char *input, unsigned char *output);
+void KangarooTwelve_AVX512_Process2Leaves(const unsigned char *input, unsigned char *output);
+
+int KeccakP1600times2_IsAvailable()
+{
+    int result = 0;
+    result |= K12_enableAVX512;
+    result |= K12_enableSSSE3;
+    return result;
+}
+
+const char * KeccakP1600times2_GetImplementation()
+{
+    if (K12_enableAVX512) {
+        return "AVX-512 implementation";
+    } else if (K12_enableSSSE3) {
+        return "SSSE3 implementation";
+    } else {
+        return "";
+    }
+}
+
+void KangarooTwelve_Process2Leaves(const unsigned char *input, unsigned char *output)
+{
+    if (K12_enableAVX512) {
+        KangarooTwelve_AVX512_Process2Leaves(input, output);
+    } else if (K12_enableSSSE3) {
+        KangarooTwelve_SSSE3_Process2Leaves(input, output);
+    }
+}
+
+
+void KangarooTwelve_AVX2_Process4Leaves(const unsigned char *input, unsigned char *output);
+void KangarooTwelve_AVX512_Process4Leaves(const unsigned char *input, unsigned char *output);
+
+int KeccakP1600times4_IsAvailable()
+{
+    int result = 0;
+    result |= K12_enableAVX512;
+    result |= K12_enableAVX2;
+    return result;
+}
+
+const char * KeccakP1600times4_GetImplementation()
+{
+    if (K12_enableAVX512) {
+        return "AVX-512 implementation";
+    } else if (K12_enableAVX2) {
+        return "AVX2 implementation";
+    } else {
+        return "";
+    }
+}
+
+void KangarooTwelve_Process4Leaves(const unsigned char *input, unsigned char *output)
+{
+    if (K12_enableAVX512) {
+        KangarooTwelve_AVX512_Process4Leaves(input, output);
+    } else if (K12_enableAVX2) {
+        KangarooTwelve_AVX2_Process4Leaves(input, output);
+    }
+}
+
+
+void KangarooTwelve_AVX512_Process8Leaves(const unsigned char *input, unsigned char *output);
+
+int KeccakP1600times8_IsAvailable()
+{
+    int result = 0;
+    result |= K12_enableAVX512;
+    return result;
+}
+
+const char * KeccakP1600times8_GetImplementation()
+{
+    if (K12_enableAVX512) {
+        return "AVX-512 implementation";
+    } else {
+        return "";
+    }
+}
+
+void KangarooTwelve_Process8Leaves(const unsigned char *input, unsigned char *output)
+{
+    if (K12_enableAVX512)
+        KangarooTwelve_AVX512_Process8Leaves(input, output);
+}
+
+#endif  // KeccakP1600_disableParallelism
+
+const char * KeccakP1600_GetImplementation()
+{
+    if (K12_enableAVX512)
+        return "AVX-512 implementation";
+    else
+#ifndef KeccakP1600_noAssembly
+    if (K12_enableAVX2)
+        return "AVX2 implementation";
+    else
+#endif
+        return "generic 64-bit implementation";
+}
+
+void KeccakP1600_Initialize(void *state)
+{
+    KangarooTwelve_SetProcessorCapabilities();
+    if (K12_enableAVX512)
+        KeccakP1600_AVX512_Initialize(state);
+    else
+#ifndef KeccakP1600_noAssembly
+    if (K12_enableAVX2)
+        KeccakP1600_AVX2_Initialize(state);
+    else
+#endif
+        KeccakP1600_opt64_Initialize(state);
+}
+
+void KeccakP1600_AddByte(void *state, unsigned char data, unsigned int offset)
+{
+    if (K12_enableAVX512)
+        ((unsigned char*)(state))[offset] ^= data;
+    else
+#ifndef KeccakP1600_noAssembly
+    if (K12_enableAVX2)
+        KeccakP1600_AVX2_AddByte(state, data, offset);
+    else
+#endif
+        KeccakP1600_opt64_AddByte(state, data, offset);
+}
+
+void KeccakP1600_AddBytes(void *state, const unsigned char *data, unsigned int offset, unsigned int length)
+{
+    if (K12_enableAVX512)
+        KeccakP1600_AVX512_AddBytes(state, data, offset, length);
+    else
+#ifndef KeccakP1600_noAssembly
+    if (K12_enableAVX2)
+        KeccakP1600_AVX2_AddBytes(state, data, offset, length);
+    else
+#endif
+        KeccakP1600_opt64_AddBytes(state, data, offset, length);
+}
+
+void KeccakP1600_Permute_12rounds(void *state)
+{
+    if (K12_enableAVX512)
+        KeccakP1600_AVX512_Permute_12rounds(state);
+    else
+#ifndef KeccakP1600_noAssembly
+    if (K12_enableAVX2)
+        KeccakP1600_AVX2_Permute_12rounds(state);
+    else
+#endif
+        KeccakP1600_opt64_Permute_12rounds(state);
+}
+
+void KeccakP1600_ExtractBytes(const void *state, unsigned char *data, unsigned int offset, unsigned int length)
+{
+    if (K12_enableAVX512)
+        KeccakP1600_AVX512_ExtractBytes(state, data, offset, length);
+    else
+#ifndef KeccakP1600_noAssembly
+    if (K12_enableAVX2)
+        KeccakP1600_AVX2_ExtractBytes(state, data, offset, length);
+    else
+#endif
+        KeccakP1600_opt64_ExtractBytes(state, data, offset, length);
+}
+
+size_t KeccakP1600_12rounds_FastLoop_Absorb(void *state, unsigned int laneCount, const unsigned char *data, size_t dataByteLen)
+{
+    if (K12_enableAVX512)
+        return KeccakP1600_AVX512_12rounds_FastLoop_Absorb(state, laneCount, data, dataByteLen);
+    else
+#ifndef KeccakP1600_noAssembly
+    if (K12_enableAVX2)
+        return KeccakP1600_AVX2_12rounds_FastLoop_Absorb(state, laneCount, data, dataByteLen);
+    else
+#endif
+        return KeccakP1600_opt64_12rounds_FastLoop_Absorb(state, laneCount, data, dataByteLen);
+}
+
+/* ---------------------------------------------------------------- */
+
+/* Processor capability detection code by Samuel Neves and Jack O'Connor, see
+ * https://github.com/BLAKE3-team/BLAKE3/blob/master/c/blake3_dispatch.c
+ */
+
+#if defined(__x86_64__) || defined(_M_X64)
+#define IS_X86
+#define IS_X86_64
+#endif
+
+#if defined(__i386__) || defined(_M_IX86)
+#define IS_X86
+#define IS_X86_32
+#endif
+
+#if defined(IS_X86)
+static uint64_t xgetbv() {
+#if defined(_MSC_VER)
+  return _xgetbv(0);
+#else
+  uint32_t eax = 0, edx = 0;
+  __asm__ __volatile__("xgetbv\n" : "=a"(eax), "=d"(edx) : "c"(0));
+  return ((uint64_t)edx << 32) | eax;
+#endif
+}
+
+static void cpuid(uint32_t out[4], uint32_t id) {
+#if defined(_MSC_VER)
+  __cpuid((int *)out, id);
+#elif defined(__i386__) || defined(_M_IX86)
+  __asm__ __volatile__("movl %%ebx, %1\n"
+                       "cpuid\n"
+                       "xchgl %1, %%ebx\n"
+                       : "=a"(out[0]), "=r"(out[1]), "=c"(out[2]), "=d"(out[3])
+                       : "a"(id));
+#else
+  __asm__ __volatile__("cpuid\n"
+                       : "=a"(out[0]), "=b"(out[1]), "=c"(out[2]), "=d"(out[3])
+                       : "a"(id));
+#endif
+}
+
+static void cpuidex(uint32_t out[4], uint32_t id, uint32_t sid) {
+#if defined(_MSC_VER)
+  __cpuidex((int *)out, id, sid);
+#elif defined(__i386__) || defined(_M_IX86)
+  __asm__ __volatile__("movl %%ebx, %1\n"
+                       "cpuid\n"
+                       "xchgl %1, %%ebx\n"
+                       : "=a"(out[0]), "=r"(out[1]), "=c"(out[2]), "=d"(out[3])
+                       : "a"(id), "c"(sid));
+#else
+  __asm__ __volatile__("cpuid\n"
+                       : "=a"(out[0]), "=b"(out[1]), "=c"(out[2]), "=d"(out[3])
+                       : "a"(id), "c"(sid));
+#endif
+}
+
+#endif
+
+enum cpu_feature {
+  SSE2 = 1 << 0,
+  SSSE3 = 1 << 1,
+  SSE41 = 1 << 2,
+  AVX = 1 << 3,
+  AVX2 = 1 << 4,
+  AVX512F = 1 << 5,
+  AVX512VL = 1 << 6,
+  /* ... */
+  UNDEFINED = 1 << 30
+};
+
+static enum cpu_feature g_cpu_features = UNDEFINED;
+
+static enum cpu_feature
+    get_cpu_features(void) {
+
+  if (g_cpu_features != UNDEFINED) {
+    return g_cpu_features;
+  } else {
+#if defined(IS_X86)
+    uint32_t regs[4] = {0};
+    uint32_t *eax = &regs[0], *ebx = &regs[1], *ecx = &regs[2], *edx = &regs[3];
+    (void)edx;
+    enum cpu_feature features = 0;
+    cpuid(regs, 0);
+    const int max_id = *eax;
+    cpuid(regs, 1);
+#if defined(__amd64__) || defined(_M_X64)
+    features |= SSE2;
+#else
+    if (*edx & (1UL << 26))
+      features |= SSE2;
+#endif
+    if (*ecx & (1UL << 0))
+      features |= SSSE3;
+    if (*ecx & (1UL << 19))
+      features |= SSE41;
+
+    if (*ecx & (1UL << 27)) { // OSXSAVE
+      const uint64_t mask = xgetbv();
+      if ((mask & 6) == 6) { // SSE and AVX states
+        if (*ecx & (1UL << 28))
+          features |= AVX;
+        if (max_id >= 7) {
+          cpuidex(regs, 7, 0);
+          if (*ebx & (1UL << 5))
+            features |= AVX2;
+          if ((mask & 224) == 224) { // Opmask, ZMM_Hi256, Hi16_Zmm
+            if (*ebx & (1UL << 31))
+              features |= AVX512VL;
+            if (*ebx & (1UL << 16))
+              features |= AVX512F;
+          }
+        }
+      }
+    }
+    g_cpu_features = features;
+    return features;
+#else
+    /* How to detect NEON? */
+    return 0;
+#endif
+  }
+}
+
+void KangarooTwelve_SetProcessorCapabilities()
+{
+    enum cpu_feature features = get_cpu_features();
+    K12_enableSSSE3 = (features & SSSE3);
+    K12_enableAVX2 = (features & AVX2);
+    K12_enableAVX512 = (features & AVX512F) && (features & AVX512VL);
+#ifdef KeccakP1600_enable_simd_options
+    K12_enableSSSE3 = K12_enableSSSE3 && !K12_SSSE3_requested_disabled;
+    K12_enableAVX2 = K12_enableAVX2 && !K12_AVX2_requested_disabled;
+    K12_enableAVX512 = K12_enableAVX512 && !K12_AVX512_requested_disabled;
+#endif  // KeccakP1600_enable_simd_options
+}
+
+#ifdef KeccakP1600_enable_simd_options
+int KangarooTwelve_DisableSSSE3(void) {
+    KangarooTwelve_SetProcessorCapabilities();
+    K12_SSSE3_requested_disabled = 1;
+    if (K12_enableSSSE3) {
+        KangarooTwelve_SetProcessorCapabilities();
+        return 1;  // SSSE3 was disabled on this call.
+    } else {
+        return 0;  // Nothing changed.
+    }
+}
+
+int KangarooTwelve_DisableAVX2(void) {
+    KangarooTwelve_SetProcessorCapabilities();
+    K12_AVX2_requested_disabled = 1;
+    if (K12_enableAVX2) {
+        KangarooTwelve_SetProcessorCapabilities();
+        return 1;  // AVX2 was disabled on this call.
+    } else {
+        return 0;  // Nothing changed.
+    }
+}
+
+int KangarooTwelve_DisableAVX512(void) {
+    KangarooTwelve_SetProcessorCapabilities();
+    K12_AVX512_requested_disabled = 1;
+    if (K12_enableAVX512) {
+        KangarooTwelve_SetProcessorCapabilities();
+        return 1;  // AVX512 was disabled on this call.
+    } else {
+        return 0;  // Nothing changed.
+    }
+}
+
+void KangarooTwelve_EnableAllCpuFeatures(void) {
+    K12_SSSE3_requested_disabled = 0;
+    K12_AVX2_requested_disabled = 0;
+    K12_AVX512_requested_disabled = 0;
+    KangarooTwelve_SetProcessorCapabilities();
+}
+#endif  // KeccakP1600_enable_simd_options

--- a/lib/Optimized64/KeccakP-1600-timesN-AVX2.c
+++ b/lib/Optimized64/KeccakP-1600-timesN-AVX2.c
@@ -21,20 +21,7 @@ Please refer to the XKCP for more details.
 #include <stdint.h>
 #include <immintrin.h>
 #include "KeccakP-1600-SnP.h"
-
-#ifdef ALIGN
-#undef ALIGN
-#endif
-
-#if defined(__GNUC__)
-#define ALIGN(x) __attribute__ ((aligned(x)))
-#elif defined(_MSC_VER)
-#define ALIGN(x) __declspec(align(x))
-#elif defined(__ARMCC_VERSION)
-#define ALIGN(x) __align(x)
-#else
-#define ALIGN(x)
-#endif
+#include "align.h"
 
 #define AVX2alignment 32
 

--- a/lib/Optimized64/KeccakP-1600-timesN-AVX512.c
+++ b/lib/Optimized64/KeccakP-1600-timesN-AVX512.c
@@ -22,20 +22,7 @@ Please refer to the XKCP for more details.
 #include <emmintrin.h>
 #include <immintrin.h>
 #include "KeccakP-1600-SnP.h"
-
-#ifdef ALIGN
-#undef ALIGN
-#endif
-
-#if defined(__GNUC__)
-#define ALIGN(x) __attribute__ ((aligned(x)))
-#elif defined(_MSC_VER)
-#define ALIGN(x) __declspec(align(x))
-#elif defined(__ARMCC_VERSION)
-#define ALIGN(x) __align(x)
-#else
-#define ALIGN(x)
-#endif
+#include "align.h"
 
 #define AVX512alignment 64
 

--- a/lib/Optimized64/KeccakP-1600-timesN-SSSE3.c
+++ b/lib/Optimized64/KeccakP-1600-timesN-SSSE3.c
@@ -21,22 +21,9 @@ Please refer to the XKCP for more details.
 #include <stdint.h>
 #include <tmmintrin.h>
 #include "KeccakP-1600-SnP.h"
+#include "align.h"
 
 #define KeccakP1600times2_SSSE3_unrolling 2
-
-#ifdef ALIGN
-#undef ALIGN
-#endif
-
-#if defined(__GNUC__)
-#define ALIGN(x) __attribute__ ((aligned(x)))
-#elif defined(_MSC_VER)
-#define ALIGN(x) __declspec(align(x))
-#elif defined(__ARMCC_VERSION)
-#define ALIGN(x) __align(x)
-#else
-#define ALIGN(x)
-#endif
 
 #define SSSE3alignment 16
 

--- a/lib/Plain64/KeccakP-1600-SnP.h
+++ b/lib/Plain64/KeccakP-1600-SnP.h
@@ -1,0 +1,48 @@
+/*
+K12 based on the eXtended Keccak Code Package (XKCP)
+https://github.com/XKCP/XKCP
+
+The Keccak-p permutations, designed by Guido Bertoni, Joan Daemen, Michaël Peeters and Gilles Van Assche.
+
+Implementation by Gilles Van Assche and Ronny Van Keer, hereby denoted as "the implementer".
+
+For more information, feedback or questions, please refer to the Keccak Team website:
+https://keccak.team/
+
+To the extent possible under law, the implementer has waived all copyright
+and related or neighboring rights to the source code in this file.
+http://creativecommons.org/publicdomain/zero/1.0/
+
+---
+
+Please refer to the XKCP for more details.
+*/
+
+#ifndef _KeccakP_1600_SnP_h_
+#define _KeccakP_1600_SnP_h_
+
+/* Keccak-p[1600] */
+
+#define KeccakP1600_stateSizeInBytes    200
+#define KeccakP1600_stateAlignment      8
+#define KeccakP1600_12rounds_FastLoop_supported
+#define KeccakP1600_disableParallelism
+
+const char * KeccakP1600_GetImplementation();
+void KeccakP1600_Initialize(void *state);
+void KeccakP1600_AddByte(void *state, unsigned char data, unsigned int offset);
+void KeccakP1600_AddBytes(void *state, const unsigned char *data, unsigned int offset, unsigned int length);
+void KeccakP1600_Permute_12rounds(void *state);
+void KeccakP1600_ExtractBytes(const void *state, unsigned char *data, unsigned int offset, unsigned int length);
+size_t KeccakP1600_12rounds_FastLoop_Absorb(void *state, unsigned int laneCount, const unsigned char *data, size_t dataByteLen);
+
+// Instead of defining proxy functions which do nothing, simply rename the
+// symbols of the opt64 implementation where they are used.
+#define KeccakP1600_opt64_Initialize KeccakP1600_Initialize
+#define KeccakP1600_opt64_AddByte KeccakP1600_AddByte
+#define KeccakP1600_opt64_AddBytes KeccakP1600_AddBytes
+#define KeccakP1600_opt64_Permute_12rounds KeccakP1600_Permute_12rounds
+#define KeccakP1600_opt64_ExtractBytes KeccakP1600_ExtractBytes
+#define KeccakP1600_opt64_12rounds_FastLoop_Absorb KeccakP1600_12rounds_FastLoop_Absorb
+
+#endif

--- a/lib/Plain64/KeccakP-1600-plain64.c
+++ b/lib/Plain64/KeccakP-1600-plain64.c
@@ -1,0 +1,24 @@
+/*
+K12 based on the eXtended Keccak Code Package (XKCP)
+https://github.com/XKCP/XKCP
+
+The Keccak-p permutations, designed by Guido Bertoni, Joan Daemen, Michaël Peeters and Gilles Van Assche.
+
+Implementation by Gilles Van Assche and Ronny Van Keer, hereby denoted as "the implementer".
+
+For more information, feedback or questions, please refer to the Keccak Team website:
+https://keccak.team/
+
+To the extent possible under law, the implementer has waived all copyright
+and related or neighboring rights to the source code in this file.
+http://creativecommons.org/publicdomain/zero/1.0/
+
+---
+
+Please refer to the XKCP for more details.
+*/
+
+const char * KeccakP1600_GetImplementation()
+{
+    return "generic 64-bit implementation";
+}

--- a/tests/testPerformance.c
+++ b/tests/testPerformance.c
@@ -45,11 +45,15 @@ uint_32t measureKangarooTwelve(uint_32t dtMin, unsigned int inputLen)
     measureTimingEnd
 }
 
+#ifndef KeccakP1600_disableParallelism
 void KangarooTwelve_SetProcessorCapabilities();
+#endif
 
 void printKangarooTwelvePerformanceHeader( void )
 {
+#ifndef KeccakP1600_disableParallelism
     KangarooTwelve_SetProcessorCapabilities();
+#endif
     printf("*** KangarooTwelve ***\n");
     printf("Using Keccak-p[1600,12] implementations:\n");
     printf("- \303\2271: %s\n", KeccakP1600_GetImplementation());


### PR DESCRIPTION
The best way turns out, once again, to be the most straightforward way.

1) Remove *all* functions that do SIMD dispatching from `KangarooTwelve.c` and `KeccakP-1600-opt64.c` and move them to a new file.
2) In lieu of creating an alternative verion of this file for the plain64 build that only proxies each function call directly to the opt64 functions, we can just rename those symbols with macros in the plain64 SnP header.

I chose to use the same `lib/Optimized64/KeccakP-1600-opt64.c` for the plain64 build, and to do that I had to change the `#include` from "quoted" to &lt;bracketed&gt;. This seems more compatible to me than my first approach of creating a symlink; Windows has some problems with symlinking sometimes (git for windows does it only since 2017 or so and still needs permissions) and honestly this just seems easier.

Re #8 I tried a few things for this, including unity builds. Building the entire library in a single TU, as it happens, degrades performance by 20% on my machine: a sure sign that this is just thinking too far ahead.

The main question I'm left with is regarding the meaning of `KeccakP1600_disableParallelism`, and how it seems to mean something different than "do not use SIMD"... but there has been some cross-bleed there, possibly my fault. I'd love for a clearer and well-documented list of configuration macros to disambiguate this, and if we can solve it here that'd be good because I don't want to break someone's corner case I didn't know about.