### PR TITLE
align struct members, not typedefs

### DIFF
--- a/lib/KangarooTwelve.h
+++ b/lib/KangarooTwelve.h
@@ -22,15 +22,15 @@ http://creativecommons.org/publicdomain/zero/1.0/
 #include "align.h"
 #include "KeccakP-1600-SnP.h"
 
-ALIGN(KeccakP1600_stateAlignment) typedef struct KangarooTwelve_FStruct {
+typedef struct KangarooTwelve_FStruct {
     uint8_t state[KeccakP1600_stateSizeInBytes];
     uint8_t byteIOIndex;
     uint8_t squeezing;
 } KangarooTwelve_F;
 
 typedef struct KangarooTwelve_InstanceStruct {
-    KangarooTwelve_F queueNode;
-    KangarooTwelve_F finalNode;
+    ALIGN(KeccakP1600_stateAlignment) KangarooTwelve_F queueNode;
+    ALIGN(KeccakP1600_stateAlignment) KangarooTwelve_F finalNode;
     size_t fixedOutputLength;
     size_t blockNumber;
     unsigned int queueAbsorbedLen;


### PR DESCRIPTION
aligning a typedef instead of the struct has very strange behavior: the type itself will not be aligned, but a field using the typedef name will have the alignment in other structs. arrays will also not have their elements aligned, but the array as a whole will be aligned.

this is very unintuitive behavior, and we should seek to avoid it. MSVC __declspec(align(N)) annotations work in the more intuitive way, such that annotating a typedef really does annotate the type, so the MSVC struct layout was formerly different; **this change should make the MSVC struct layout the same as it is on gcc/clang** (by allowing the integer fields of KangarooTwelve_Instance to directly follow finalNode rather than its padding).

an example of the aligned-typedef weirdness: https://gist.github.com/mumbleskates/17b7da5ffbd50686a3b9a4a36e5d8132

ideally this will alleviate some of the problems such as issues with bindgen's understanding of the alignment: https://github.com/oconnor663/kangarootwelve_xkcp.rs/issues/1#issuecomment-633800659