### PR TITLE
Fix alignment of rho constants for MSVC

### DIFF
--- a/lib/Optimized64/KeccakP-1600-timesN-AVX2.c
+++ b/lib/Optimized64/KeccakP-1600-timesN-AVX2.c
@@ -33,8 +33,8 @@ Please refer to the XKCP for more details.
 #define ROL64in256(d, a, o)     d = _mm256_or_si256(_mm256_slli_epi64(a, o), _mm256_srli_epi64(a, 64-(o)))
 #define ROL64in256_8(d, a)      d = _mm256_shuffle_epi8(a, CONST256(rho8))
 #define ROL64in256_56(d, a)     d = _mm256_shuffle_epi8(a, CONST256(rho56))
-static const uint64_t rho8[4] ALIGN(32) = {0x0605040302010007, 0x0E0D0C0B0A09080F, 0x1615141312111017, 0x1E1D1C1B1A19181F};
-static const uint64_t rho56[4] ALIGN(32) = {0x0007060504030201, 0x080F0E0D0C0B0A09, 0x1017161514131211, 0x181F1E1D1C1B1A19};
+static ALIGN(AVX2alignment) const uint64_t rho8[4] = {0x0605040302010007, 0x0E0D0C0B0A09080F, 0x1615141312111017, 0x1E1D1C1B1A19181F};
+static ALIGN(AVX2alignment) const uint64_t rho56[4] = {0x0007060504030201, 0x080F0E0D0C0B0A09, 0x1017161514131211, 0x181F1E1D1C1B1A19};
 #define STORE256(a, b)          _mm256_store_si256((__m256i *)&(a), b)
 #define STORE256u(a, b)         _mm256_storeu_si256((__m256i *)&(a), b)
 #define XOR256(a, b)            _mm256_xor_si256(a, b)


### PR DESCRIPTION
This makes the order of align statements consistent with other usages, on declarations like KeccakP1600RoundConstants

Fixes #16 