### PR TITLE
KT256

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,6 +19,6 @@ jobs:
     - name: Install xsltproc
       run: sudo apt-get install xsltproc
     - name: Build
-      run: make ${{ matrix.target }}/K12Tests ${{ matrix.target }}/libk12.a ${{ matrix.target }}/libk12.so
+      run: make ${{ matrix.target }}/KTtests ${{ matrix.target }}/libKT.a ${{ matrix.target }}/libKT.so
     - name: Test
-      run: bin/${{ matrix.target }}/K12Tests -K12
+      run: bin/${{ matrix.target }}/KTtests -K12

--- a/Makefile.build
+++ b/Makefile.build
@@ -79,7 +79,7 @@ http://creativecommons.org/publicdomain/zero/1.0/
     </fragment>
 
     <!-- To run many tests -->
-    <fragment name="K12Tests" inherits="common KangarooTwelve">
+    <fragment name="KTtests" inherits="common KangarooTwelve">
         <c>tests/main.c</c>
         <c>tests/testPerformance.c</c>
         <c>tests/timing.c</c>
@@ -92,9 +92,9 @@ http://creativecommons.org/publicdomain/zero/1.0/
     </fragment>
 
     <!-- To make a library -->
-    <fragment name="libk12.a" inherits="KangarooTwelve"/>
-    <fragment name="libk12.so" inherits="KangarooTwelve"/>
-    <fragment name="libk12.dylib" inherits="KangarooTwelve"/>
+    <fragment name="libKT.a" inherits="KangarooTwelve"/>
+    <fragment name="libKT.so" inherits="KangarooTwelve"/>
+    <fragment name="libKT.dylib" inherits="KangarooTwelve"/>
 
     <!-- Generically optimized 32-bit implementation -->
     <fragment name="generic32" inherits="inplace32bi"/>
@@ -112,7 +112,7 @@ http://creativecommons.org/publicdomain/zero/1.0/
     <group all="all">
         <product delimiter="/">
             <factor set="generic32 generic64 generic64noAsm plain64 ARMv8Asha3"/>
-            <factor set="K12Tests libk12.a libk12.so libk12.dylib"/>
+            <factor set="KTtests libKT.a libKT.so libKT.dylib"/>
         </product>
     </group>
 </build>

--- a/README.markdown
+++ b/README.markdown
@@ -1,37 +1,37 @@
 # What is KangarooTwelve ?
 
-[**KangarooTwelve**][k12] (or **K12**) is a fast and secure extendable-output function (XOF), the generalization of hash functions to arbitrary output lengths.
-Derived from Keccak, it aims at higher speeds than FIPS 202's SHA-3 and SHAKE functions, while retaining their flexibility and basis of security.
+[**KangarooTwelve**][k12] is a family of two (**KT128** and **KT256**) fast and secure extendable-output functions (XOF), the generalization of hash functions to arbitrary output lengths.
+Derived from Keccak, they aim at higher speeds than FIPS 202's SHA-3 and SHAKE functions, while retaining their flexibility and basis of security.
 
-On high-end platforms, it can exploit a high degree of parallelism, whether using multiple cores or the single-instruction multiple-data (SIMD) instruction set of modern processors.
-On Intel's Haswell and Skylake architectures, KangarooTwelve tops at less than 1.5 cycles/byte for long messages on a single core, and at 0.51 cycles/byte on the SkylakeX and Cascade Lake architectures.
-On the latest Apple A14 and M1 processors, KangarooTwelve can take advantage of the ARMv8-A's SHA-3 dedicated instructions to deliver 0.75 cycles/byte for long messages on a single core.
-On low-end platforms, as well as for short messages, it also benefits from about a factor two speed-up compared to the fastest FIPS 202 instance SHAKE128.
+On high-end platforms, they can exploit a high degree of parallelism, whether using multiple cores or the single-instruction multiple-data (SIMD) instruction set of modern processors.
+On Intel's Haswell and Skylake architectures, KT128 tops at less than 1.5 cycles/byte for long messages on a single core, and at 0.51 cycles/byte on the SkylakeX and Cascade Lake architectures.
+On the latest Apple A14 and M1 processors, KangarooTwelve can take advantage of the ARMv8-A's SHA-3 dedicated instructions and KT128 delivers 0.75 cycles/byte for long messages on a single core.
+On low-end platforms, as well as for short messages, KT128 also benefits from about a factor two speed-up compared to the fastest FIPS 202 instance SHAKE128.
 
-More details can be found in our [ACNS Paper][eprint].
+More details can be found in our [ACNS paper][eprint] (KT128 only) and in the [RFC draft](ietf).
 
 # What can I find here?
 
-This repository contains source code that implements the extandable output (or hash) function [**KangarooTwelve**][k12] (or **K12**).
-Its purpose is to offer optimized implementations of K12 and nothing else.
+This repository contains source code that implements the extendable output (or hash) function **KT128** and **KT256**.
+Its purpose is to offer optimized implementations of the KangarooTwelve and nothing else.
 
-The code comes from the [**eXtended Keccak Code Package**][xkcp] (or **XKCP**), after much trimming to keep only what is needed for K12.
-It is still structured like the XKCP in two layers. The lower layer implements the permutation Keccak-_p_[1600, 12] and possibly parallel versions thereof, whereas the higher layer implements the sponge construction and the K12 tree hash mode.
+The code comes from the [**eXtended Keccak Code Package**][xkcp] (or **XKCP**), after much trimming to keep only what is needed for KT.
+It is still structured like the XKCP in two layers. The lower layer implements the permutation Keccak-_p_[1600, 12] and possibly parallel versions thereof, whereas the higher layer implements the sponge construction and the tree hash mode.
 Also, some sources have been merged to reduce the file count.
 
-* For the higher layer, we kept only the code needed for K12.
-* For the lower layer, we removed all the functions that are not needed for K12. The lower layer therefore implements a subset of the SnP and PlSnP interfaces.
+* For the higher layer, we kept only the code needed for KT.
+* For the lower layer, we removed all the functions that are not needed for KT. The lower layer therefore implements a subset of the SnP and PlSnP interfaces.
 
-For Keccak or Xoodoo-based functions other than K12 only, it is recommended to use the XKCP itself instead and not to mix both this repository and the XKCP.
+For Keccak or Xoodoo-based functions other than KT128 and KT256, it is recommended to use the XKCP itself instead and not to mix both this repository and the XKCP.
 
 
-# Is there a tool to compute the K12 hash of a file?
+# Is there a tool to compute the hash of a file?
 
 Not in this repository, but Jack O'Connor's [`kangarootwelve_xkcp.rs` repository](https://github.com/oconnor663/kangarootwelve_xkcp.rs) contains Rust bindings to this code and a `k12sum` utility.
 Pre-built binaries can be found [there](https://github.com/oconnor663/kangarootwelve_xkcp.rs/releases).
 
 
-# How can I build this K12 code?
+# How can I build this code?
 
 This repository uses the same build system as that of the XKCP.
 To build, the following tools are needed:
@@ -72,6 +72,7 @@ Please refer to the documention of [XKCP][xkcp] for more details on the limitati
 [k12]: https://keccak.team/kangarootwelve.html
 [xkcp]: https://github.com/XKCP/XKCP
 [eprint]: https://eprint.iacr.org/2016/770.pdf
+[ietf]: https://datatracker.ietf.org/doc/draft-irtf-cfrg-kangarootwelve/
 
 
 # Acknowledgments
@@ -82,3 +83,4 @@ We wish to thank:
 - Duc Tri Nguyen for his benchmark on the Apple M1
 - Jack O'Connor for bug fixes and more importantly for his [Rust bindings](https://github.com/oconnor663/kangarootwelve_xkcp.rs)
 - Kent Ross for his contributions to this code and its quality
+- Hadi El Yakhni for adding KT256

--- a/lib/ARMv8Asha3/KeccakP-1600-ARMv8Asha3.S
+++ b/lib/ARMv8Asha3/KeccakP-1600-ARMv8Asha3.S
@@ -219,7 +219,7 @@ KeccakP1600_ARMv8Asha3_Permute_12rounds:
 
 // size_t KeccakP1600_ARMv8Asha3_12rounds_FastLoop_Absorb(
 //      void *state(x0),
-//      unsigned int laneCount(x1) = 21,
+//      unsigned int laneCount(x1) = 17 or 21,
 //      const unsigned char *data(x2),
 //      size_t dataByteLen(x3))
 .ifdef macOS
@@ -254,10 +254,14 @@ KeccakP1600_ARMv8Asha3_12rounds_FastLoop_Absorb:
 
     // Prepare the return value
     mov x11, #0
-    b .KeccakP1600_ARMv8Asha3_12rounds_FastLoop_Absorb_loop
+
+    cmp x1, #17
+    b.eq .KeccakP1600_ARMv8Asha3_12rounds_FastLoop_Absorb_loop_17
+
+    b .KeccakP1600_ARMv8Asha3_12rounds_FastLoop_Absorb_loop_21
 
 .balign 16
-.KeccakP1600_ARMv8Asha3_12rounds_FastLoop_Absorb_loop:
+.KeccakP1600_ARMv8Asha3_12rounds_FastLoop_Absorb_loop_21:
     subs x3, x3, #8*21
     b.cc .KeccakP1600_ARMv8Asha3_12rounds_FastLoop_Absorb_end
 
@@ -302,7 +306,51 @@ KeccakP1600_ARMv8Asha3_12rounds_FastLoop_Absorb:
 
     add x11, x11, #8*21
 
-    b .KeccakP1600_ARMv8Asha3_12rounds_FastLoop_Absorb_loop
+    b .KeccakP1600_ARMv8Asha3_12rounds_FastLoop_Absorb_loop_21
+
+.balign 16
+.KeccakP1600_ARMv8Asha3_12rounds_FastLoop_Absorb_loop_17:
+    subs x3, x3, #8*17
+    b.cc .KeccakP1600_ARMv8Asha3_12rounds_FastLoop_Absorb_end
+
+    // Lanes 0-3
+    ld1 {v27.8b-v30.8b}, [x2], #32
+    eor  v0.16b,  v0.16b, v27.16b
+    eor  v1.16b,  v1.16b, v28.16b
+    eor  v2.16b,  v2.16b, v29.16b
+    eor  v3.16b,  v3.16b, v30.16b
+
+    // Lanes 4-7
+    ld1 {v27.8b-v30.8b}, [x2], #32
+    eor  v4.16b,  v4.16b, v27.16b
+    eor  v5.16b,  v5.16b, v28.16b
+    eor  v6.16b,  v6.16b, v29.16b
+    eor  v7.16b,  v7.16b, v30.16b
+
+    // Lanes 8-11
+    ld1 {v27.8b-v30.8b}, [x2], #32
+    eor  v8.16b,  v8.16b, v27.16b
+    eor  v9.16b,  v9.16b, v28.16b
+    eor v10.16b, v10.16b, v29.16b
+    eor v11.16b, v11.16b, v30.16b
+
+    // Lanes 12-15
+    ld1 {v27.8b-v30.8b}, [x2], #32
+    eor v12.16b, v12.16b, v27.16b
+    eor v13.16b, v13.16b, v28.16b
+    eor v14.16b, v14.16b, v29.16b
+    eor v15.16b, v15.16b, v30.16b
+
+    // Lane 16
+    ld1 {v27.8b}, [x2], #8
+    eor v16.16b, v16.16b, v27.16b
+
+    bl KeccakP1600_ARMv8Asha3_Permute_12rounds_internal
+
+    add x11, x11, #8*17
+
+    b .KeccakP1600_ARMv8Asha3_12rounds_FastLoop_Absorb_loop_17
+
 .KeccakP1600_ARMv8Asha3_12rounds_FastLoop_Absorb_end:
 
     stp d0,d1,[x0,#8*0]
@@ -383,12 +431,12 @@ KeccakP1600times2_ARMv8Asha3_Permute_12rounds:
 .endif
 
 .ifdef macOS
-.globl  _KangarooTwelve_ARMv8Asha3_Process2Leaves
-_KangarooTwelve_ARMv8Asha3_Process2Leaves:
+.globl  _KT128_ARMv8Asha3_Process2Leaves
+_KT128_ARMv8Asha3_Process2Leaves:
 .else
-.globl  KangarooTwelve_ARMv8Asha3_Process2Leaves
-.type   KangarooTwelve_ARMv8Asha3_Process2Leaves,%function
-KangarooTwelve_ARMv8Asha3_Process2Leaves:
+.globl  KT128_ARMv8Asha3_Process2Leaves
+.type   KT128_ARMv8Asha3_Process2Leaves,%function
+KT128_ARMv8Asha3_Process2Leaves:
 .endif
 .balign 32
     stp x29,x30,[sp,#-80]!
@@ -429,8 +477,8 @@ KangarooTwelve_ARMv8Asha3_Process2Leaves:
 
     // Loop over the first 48 blocks
     mov x11, 48
-    b .KangarooTwelve_ARMv8Asha3_Process2Leaves_blocks
-.KangarooTwelve_ARMv8Asha3_Process2Leaves_blocks:
+    b .KT128_ARMv8Asha3_Process2Leaves_blocks
+.KT128_ARMv8Asha3_Process2Leaves_blocks:
 
     // Lanes 0-3
     ld1 {v25.1d-v28.1d}, [x0], #32
@@ -524,7 +572,7 @@ KangarooTwelve_ARMv8Asha3_Process2Leaves:
     bl KeccakP1600_ARMv8Asha3_Permute_12rounds_internal
 
     subs x11, x11, #1
-    bne .KangarooTwelve_ARMv8Asha3_Process2Leaves_blocks
+    bne .KT128_ARMv8Asha3_Process2Leaves_blocks
 
     // Lanes 0-3
     ld1 {v25.1d-v28.1d}, [x0], #32
@@ -619,5 +667,186 @@ KangarooTwelve_ARMv8Asha3_Process2Leaves:
     ret
 .ifdef macOS
 .else
-.size   KangarooTwelve_ARMv8Asha3_Process2Leaves,.-KangarooTwelve_ARMv8Asha3_Process2Leaves
+.size   KT128_ARMv8Asha3_Process2Leaves,.-KT128_ARMv8Asha3_Process2Leaves
+.endif
+
+.ifdef macOS
+.globl  _KT256_ARMv8Asha3_Process2Leaves
+_KT256_ARMv8Asha3_Process2Leaves:
+.else
+.globl  KT256_ARMv8Asha3_Process2Leaves
+.type   KT256_ARMv8Asha3_Process2Leaves,%function
+KT256_ARMv8Asha3_Process2Leaves:
+.endif
+.balign 32
+    stp x29,x30,[sp,#-80]!
+    add x29,sp,#0
+    stp d8,d9,[sp,#16]      // per ABI requirement
+    stp d10,d11,[sp,#32]
+    stp d12,d13,[sp,#48]
+    stp d14,d15,[sp,#64]
+
+    movi  v0.2d, #0
+    movi  v1.2d, #0
+    movi  v2.2d, #0
+    movi  v3.2d, #0
+    movi  v4.2d, #0
+    movi  v5.2d, #0
+    movi  v6.2d, #0
+    movi  v7.2d, #0
+    movi  v8.2d, #0
+    movi  v9.2d, #0
+    movi v10.2d, #0
+    movi v11.2d, #0
+    movi v12.2d, #0
+    movi v13.2d, #0
+    movi v14.2d, #0
+    movi v15.2d, #0
+    movi v16.2d, #0
+    movi v17.2d, #0
+    movi v18.2d, #0
+    movi v19.2d, #0
+    movi v20.2d, #0
+    movi v21.2d, #0
+    movi v22.2d, #0
+    movi v23.2d, #0
+    movi v24.2d, #0
+
+    // x12 is input + chunkSize
+    add x12, x0, #8192
+
+    // Loop over the first 60 blocks
+    mov x11, 60
+    b .KT256_ARMv8Asha3_Process2Leaves_blocks
+.KT256_ARMv8Asha3_Process2Leaves_blocks:
+
+    // Lanes 0-3
+    ld1 {v25.1d-v28.1d}, [x0], #32
+    ld1 {v25.d}[1], [x12], #8
+    ld1 {v26.d}[1], [x12], #8
+    ld1 {v27.d}[1], [x12], #8
+    ld1 {v28.d}[1], [x12], #8
+#ifdef  __AARCH64EB__
+    rev64 v25.16b, v25.16b
+    rev64 v26.16b, v26.16b
+    rev64 v27.16b, v27.16b
+    rev64 v28.16b, v28.16b
+#endif
+    eor v0.16b, v0.16b, v25.16b
+    eor v1.16b, v1.16b, v26.16b
+    eor v2.16b, v2.16b, v27.16b
+    eor v3.16b, v3.16b, v28.16b
+
+    // Lanes 4-7
+    ld1 {v25.1d-v28.1d}, [x0], #32
+    ld1 {v25.d}[1], [x12], #8
+    ld1 {v26.d}[1], [x12], #8
+    ld1 {v27.d}[1], [x12], #8
+    ld1 {v28.d}[1], [x12], #8
+#ifdef  __AARCH64EB__
+    rev64 v25.16b, v25.16b
+    rev64 v26.16b, v26.16b
+    rev64 v27.16b, v27.16b
+    rev64 v28.16b, v28.16b
+#endif
+    eor v4.16b, v4.16b, v25.16b
+    eor v5.16b, v5.16b, v26.16b
+    eor v6.16b, v6.16b, v27.16b
+    eor v7.16b, v7.16b, v28.16b
+
+    // Lanes 8-11
+    ld1 {v25.1d-v28.1d}, [x0], #32
+    ld1 {v25.d}[1], [x12], #8
+    ld1 {v26.d}[1], [x12], #8
+    ld1 {v27.d}[1], [x12], #8
+    ld1 {v28.d}[1], [x12], #8
+#ifdef  __AARCH64EB__
+    rev64 v25.16b, v25.16b
+    rev64 v26.16b, v26.16b
+    rev64 v27.16b, v27.16b
+    rev64 v28.16b, v28.16b
+#endif
+    eor  v8.16b,  v8.16b, v25.16b
+    eor  v9.16b,  v9.16b, v26.16b
+    eor v10.16b, v10.16b, v27.16b
+    eor v11.16b, v11.16b, v28.16b
+
+    // Lanes 12-15
+    ld1 {v25.1d-v28.1d}, [x0], #32
+    ld1 {v25.d}[1], [x12], #8
+    ld1 {v26.d}[1], [x12], #8
+    ld1 {v27.d}[1], [x12], #8
+    ld1 {v28.d}[1], [x12], #8
+#ifdef  __AARCH64EB__
+    rev64 v25.16b, v25.16b
+    rev64 v26.16b, v26.16b
+    rev64 v27.16b, v27.16b
+    rev64 v28.16b, v28.16b
+#endif
+    eor v12.16b, v12.16b, v25.16b
+    eor v13.16b, v13.16b, v26.16b
+    eor v14.16b, v14.16b, v27.16b
+    eor v15.16b, v15.16b, v28.16b
+
+    // Lane 16
+    ld1 {v25.d}[0], [x0], #8
+    ld1 {v25.d}[1], [x12], #8
+#ifdef  __AARCH64EB__
+    rev64 v25.16b, v25.16b
+#endif
+    eor v16.16b, v16.16b, v25.16b
+
+    bl KeccakP1600_ARMv8Asha3_Permute_12rounds_internal
+
+    subs x11, x11, #1
+    bne .KT256_ARMv8Asha3_Process2Leaves_blocks
+
+    // Lanes 0-3
+    ld1 {v25.1d-v28.1d}, [x0], #32
+    ld1 {v25.d}[1], [x12], #8
+    ld1 {v26.d}[1], [x12], #8
+    ld1 {v27.d}[1], [x12], #8
+    ld1 {v28.d}[1], [x12], #8
+#ifdef  __AARCH64EB__
+    rev64 v25.16b, v25.16b
+    rev64 v26.16b, v26.16b
+    rev64 v27.16b, v27.16b
+    rev64 v28.16b, v28.16b
+#endif
+    eor v0.16b, v0.16b, v25.16b
+    eor v1.16b, v1.16b, v26.16b
+    eor v2.16b, v2.16b, v27.16b
+    eor v3.16b, v3.16b, v28.16b
+
+    mov x13, #0x0B
+    dup v25.2d, x13
+    mov x13, #0x8000000000000000
+    dup v26.2d, x13
+    eor  v4.16b,  v4.16b, v25.16b
+    eor v16.16b, v16.16b, v26.16b
+
+    bl KeccakP1600_ARMv8Asha3_Permute_12rounds_internal
+
+    st1 {v0.1d-v3.1d}, [x1], #32
+    st1 {v4.1d-v7.1d}, [x1], #32
+    st1 {v0.d}[1], [x1], #8
+    st1 {v1.d}[1], [x1], #8
+    st1 {v2.d}[1], [x1], #8
+    st1 {v3.d}[1], [x1], #8
+    st1 {v4.d}[1], [x1], #8
+    st1 {v5.d}[1], [x1], #8
+    st1 {v6.d}[1], [x1], #8
+    st1 {v7.d}[1], [x1], #8
+
+    ldr x30,[sp,#8]
+    ldp d8,d9,[sp,#16]
+    ldp d10,d11,[sp,#32]
+    ldp d12,d13,[sp,#48]
+    ldp d14,d15,[sp,#64]
+    ldr x29,[sp],#80
+
+    ret
+.ifdef macOS
+.else
+.size   KT256_ARMv8Asha3_Process2Leaves,.-KT256_ARMv8Asha3_Process2Leaves
 .endif

--- a/lib/ARMv8Asha3/KeccakP-1600-SnP.h
+++ b/lib/ARMv8Asha3/KeccakP-1600-SnP.h
@@ -50,7 +50,7 @@ void KeccakP1600times2_ARMv8Asha3_Permute_12rounds(void *state);
 void KangarooTwelve_ARMv8Asha3_Process2Leaves(const unsigned char *input, unsigned char *output);
 
 #define KeccakP1600times2_Permute_12rounds KeccakP1600times2_ARMv8Asha3_Permute_12rounds
-#define KangarooTwelve_Process2Leaves KangarooTwelve_ARMv8Asha3_Process2Leaves
+#define KT128_Process2Leaves KangarooTwelve_ARMv8Asha3_Process2Leaves
 
 /* Keccak-p[1600]×4 */
 

--- a/lib/ARMv8Asha3/KeccakP-1600-SnP.h
+++ b/lib/ARMv8Asha3/KeccakP-1600-SnP.h
@@ -47,10 +47,12 @@ size_t KeccakP1600_ARMv8Asha3_12rounds_FastLoop_Absorb(void *state, unsigned int
 int KeccakP1600times2_IsAvailable();
 const char * KeccakP1600times2_GetImplementation();
 void KeccakP1600times2_ARMv8Asha3_Permute_12rounds(void *state);
-void KangarooTwelve_ARMv8Asha3_Process2Leaves(const unsigned char *input, unsigned char *output);
+void KT128_ARMv8Asha3_Process2Leaves(const unsigned char *input, unsigned char *output);
+void KT256_ARMv8Asha3_Process2Leaves(const unsigned char *input, unsigned char *output);
 
 #define KeccakP1600times2_Permute_12rounds KeccakP1600times2_ARMv8Asha3_Permute_12rounds
-#define KT128_Process2Leaves KangarooTwelve_ARMv8Asha3_Process2Leaves
+#define KT128_Process2Leaves KT128_ARMv8Asha3_Process2Leaves
+#define KT256_Process2Leaves KT256_ARMv8Asha3_Process2Leaves
 
 /* Keccak-p[1600]×4 */
 

--- a/lib/ARMv8Asha3/KeccakP-1600-opt64.c
+++ b/lib/ARMv8Asha3/KeccakP-1600-opt64.c
@@ -210,6 +210,10 @@ void KT128_Process4Leaves(const unsigned char *input, unsigned char *output)
 {
 }
 
+void KT256_Process4Leaves(const unsigned char *input, unsigned char *output)
+{
+}
+
 /* Keccak-p[1600]×8 */
 
 int KeccakP1600times8_IsAvailable()
@@ -223,5 +227,9 @@ const char * KeccakP1600times8_GetImplementation()
 }
 
 void KT128_Process8Leaves(const unsigned char *input, unsigned char *output)
+{
+}
+
+void KT256_Process8Leaves(const unsigned char *input, unsigned char *output)
 {
 }

--- a/lib/ARMv8Asha3/KeccakP-1600-opt64.c
+++ b/lib/ARMv8Asha3/KeccakP-1600-opt64.c
@@ -206,7 +206,7 @@ const char * KeccakP1600times4_GetImplementation()
     return "";
 }
 
-void KangarooTwelve_Process4Leaves(const unsigned char *input, unsigned char *output)
+void KT128_Process4Leaves(const unsigned char *input, unsigned char *output)
 {
 }
 
@@ -222,6 +222,6 @@ const char * KeccakP1600times8_GetImplementation()
     return "";
 }
 
-void KangarooTwelve_Process8Leaves(const unsigned char *input, unsigned char *output)
+void KT128_Process8Leaves(const unsigned char *input, unsigned char *output)
 {
 }

--- a/lib/KangarooTwelve.c
+++ b/lib/KangarooTwelve.c
@@ -197,7 +197,7 @@ static unsigned int right_encode(unsigned char * encbuf, size_t value)
     return n + 1;
 }
 
-int KangarooTwelve_Initialize(KangarooTwelve_Instance *ktInstance, size_t outputByteLen, int securityLevel)
+int KangarooTwelve_Initialize(KangarooTwelve_Instance *ktInstance, int securityLevel, size_t outputByteLen)
 {
     ktInstance->fixedOutputLength = outputByteLen;
     ktInstance->queueAbsorbedLen = 0;
@@ -337,15 +337,15 @@ int KangarooTwelve_Squeeze(KangarooTwelve_Instance *ktInstance, unsigned char *o
     return 0;
 }
 
-int KangarooTwelve(const unsigned char *input, size_t inputByteLen,
+int KangarooTwelve(int securityLevel, const unsigned char *input, size_t inputByteLen,
                    unsigned char *output, size_t outputByteLen,
-                   const unsigned char *customization, size_t customByteLen, int securityLevel)
+                   const unsigned char *customization, size_t customByteLen)
 {
     KangarooTwelve_Instance ktInstance;
 
     if (outputByteLen == 0)
         return 1;
-    KangarooTwelve_Initialize(&ktInstance, outputByteLen, securityLevel);
+    KangarooTwelve_Initialize(&ktInstance, securityLevel, outputByteLen);
     if (KangarooTwelve_Update(&ktInstance, input, inputByteLen) != 0)
         return 1;
     return KangarooTwelve_Final(&ktInstance, output, customization, customByteLen);
@@ -357,12 +357,12 @@ int KT128(const unsigned char *input, size_t inputByteLen,
                    unsigned char *output, size_t outputByteLen,
                    const unsigned char *customization, size_t customByteLen)
 {
-    return KangarooTwelve(input, inputByteLen, output, outputByteLen, customization, customByteLen, 128);
+    return KangarooTwelve(128, input, inputByteLen, output, outputByteLen, customization, customByteLen);
 }
 
 int KT256(const unsigned char *input, size_t inputByteLen,
                    unsigned char *output, size_t outputByteLen,
                    const unsigned char *customization, size_t customByteLen)
 {
-    return KangarooTwelve(input, inputByteLen, output, outputByteLen, customization, customByteLen, 256);
+    return KangarooTwelve(256, input, inputByteLen, output, outputByteLen, customization, customByteLen);
 }

--- a/lib/KangarooTwelve.c
+++ b/lib/KangarooTwelve.c
@@ -16,7 +16,6 @@ http://creativecommons.org/publicdomain/zero/1.0/
 
 #include <assert.h>
 #include <string.h>
-#include <stdio.h>
 #include "KangarooTwelve.h"
 #include "KeccakP-1600-SnP.h"
 

--- a/lib/KangarooTwelve.c
+++ b/lib/KangarooTwelve.c
@@ -43,15 +43,12 @@ static void TurboSHAKE_Absorb(TurboSHAKE_Instance *instance, const unsigned char
     curData = data;
     while(i < dataByteLen) {
         if ((instance->byteIOIndex == 0) && (dataByteLen-i >= rateInBytes)) {
-            // TODO: the below function fails with KT256 because it assumes that the 
-            //  laneCount is 21, however, in the case of KT256, it's 17. So for now,
-            //  I am commenting it till the fix is found.
-// #ifdef KeccakP1600_12rounds_FastLoop_supported
-//             /* processing full blocks first */
-//             j = KeccakP1600_12rounds_FastLoop_Absorb(instance->state, instance->rate/64, curData, dataByteLen - i);
-//             i += j;
-//             curData += j;
-// #endif
+#ifdef KeccakP1600_12rounds_FastLoop_supported
+            /* processing full blocks first */
+            j = KeccakP1600_12rounds_FastLoop_Absorb(instance->state, instance->rate/64, curData, dataByteLen - i);
+            i += j;
+            curData += j;
+#endif
             for(j=dataByteLen-i; j>=rateInBytes; j-=rateInBytes) {
                 KeccakP1600_AddBytes(instance->state, curData, 0, rateInBytes);
                 KeccakP1600_Permute_12rounds(instance->state);

--- a/lib/KangarooTwelve.c
+++ b/lib/KangarooTwelve.c
@@ -148,10 +148,10 @@ typedef KCP_Phases KangarooTwelve_Phases;
 
 #ifndef KeccakP1600_disableParallelism
 
-// TODO: rename the blow functions to KT128_Process{n}Leaves and, create the KT256_Process{n}Leaves variations.
-void KangarooTwelve_Process2Leaves(const unsigned char *input, unsigned char *output);
-void KangarooTwelve_Process4Leaves(const unsigned char *input, unsigned char *output);
-void KangarooTwelve_Process8Leaves(const unsigned char *input, unsigned char *output);
+// TODO: create the KT256_Process{n}Leaves variations and wire them up
+void KT128_Process2Leaves(const unsigned char *input, unsigned char *output);
+void KT128_Process4Leaves(const unsigned char *input, unsigned char *output);
+void KT128_Process8Leaves(const unsigned char *input, unsigned char *output);
 
 #define ProcessLeaves( Parallellism, CapacityInBytes ) \
     while (inputByteLen >= Parallellism * K12_chunkSize) { \

--- a/lib/KangarooTwelve.c
+++ b/lib/KangarooTwelve.c
@@ -148,6 +148,7 @@ typedef KCP_Phases KangarooTwelve_Phases;
 
 #ifndef KeccakP1600_disableParallelism
 
+// TODO: rename the blow functions to KT128_Process{n}Leaves and, create the KT256_Process{n}Leaves variations.
 void KangarooTwelve_Process2Leaves(const unsigned char *input, unsigned char *output);
 void KangarooTwelve_Process4Leaves(const unsigned char *input, unsigned char *output);
 void KangarooTwelve_Process8Leaves(const unsigned char *input, unsigned char *output);

--- a/lib/KangarooTwelve.c
+++ b/lib/KangarooTwelve.c
@@ -157,7 +157,7 @@ void KT128_Process8Leaves(const unsigned char *input, unsigned char *output);
     while (inputByteLen >= Parallellism * K12_chunkSize) { \
         unsigned char intermediate[Parallellism * CapacityInBytes]; \
         \
-        KangarooTwelve_Process##Parallellism##Leaves(input, intermediate); \
+        KT128##Parallellism##Leaves(input, intermediate); \
         input += Parallellism * K12_chunkSize; \
         inputByteLen -= Parallellism * K12_chunkSize; \
         ktInstance->blockNumber += Parallellism; \

--- a/lib/KangarooTwelve.h
+++ b/lib/KangarooTwelve.h
@@ -26,6 +26,7 @@ http://creativecommons.org/publicdomain/zero/1.0/
 
 typedef struct TurboSHAKE128_InstanceStruct {
     uint8_t state[KeccakP1600_stateSizeInBytes];
+    unsigned int rate;
     uint8_t byteIOIndex;
     uint8_t squeezing;
 } TurboSHAKE128_Instance;

--- a/lib/KangarooTwelve.h
+++ b/lib/KangarooTwelve.h
@@ -24,20 +24,21 @@ http://creativecommons.org/publicdomain/zero/1.0/
 
 // TODO: add the `securityLevel` parameter to the documentation comments
 
-typedef struct TurboSHAKE128_InstanceStruct {
+typedef struct TurboSHAKE_InstanceStruct {
     uint8_t state[KeccakP1600_stateSizeInBytes];
     unsigned int rate;
     uint8_t byteIOIndex;
     uint8_t squeezing;
-} TurboSHAKE128_Instance;
+} TurboSHAKE_Instance;
 
 typedef struct KangarooTwelve_InstanceStruct {
-    ALIGN(KeccakP1600_stateAlignment) TurboSHAKE128_Instance queueNode;
-    ALIGN(KeccakP1600_stateAlignment) TurboSHAKE128_Instance finalNode;
+    ALIGN(KeccakP1600_stateAlignment) TurboSHAKE_Instance queueNode;
+    ALIGN(KeccakP1600_stateAlignment) TurboSHAKE_Instance finalNode;
     size_t fixedOutputLength;
     size_t blockNumber;
     unsigned int queueAbsorbedLen;
     int phase;
+    int securityLevel;
 } KangarooTwelve_Instance;
 
 /** Extendable ouput function KangarooTwelve.
@@ -59,6 +60,12 @@ int KangarooTwelve(const unsigned char *input, size_t inputByteLen, unsigned cha
   * @return 0 if successful, 1 otherwise.
   */
 int KangarooTwelve_Initialize(KangarooTwelve_Instance *ktInstance, size_t outputByteLen, int securityLevel);
+
+#define KT128_Initialize(instance, outputByteLen) \
+    KangarooTwelve_Initialize((instance), (outputByteLen), 128);
+
+#define KT256_Initialize(instance, outputByteLen) \
+    KangarooTwelve_Initialize((instance), (outputByteLen), 256);
 
 /**
   * Function to give input data to be absorbed.

--- a/lib/KangarooTwelve.h
+++ b/lib/KangarooTwelve.h
@@ -22,6 +22,8 @@ http://creativecommons.org/publicdomain/zero/1.0/
 #include "align.h"
 #include "KeccakP-1600-SnP.h"
 
+// TODO: add the `securityLevel` parameter to the documentation comments
+
 typedef struct TurboSHAKE128_InstanceStruct {
     uint8_t state[KeccakP1600_stateSizeInBytes];
     uint8_t byteIOIndex;
@@ -46,7 +48,7 @@ typedef struct KangarooTwelve_InstanceStruct {
   * @param  customByteLen   The length of the customization string in bytes.
   * @return 0 if successful, 1 otherwise.
   */
-int KangarooTwelve(const unsigned char *input, size_t inputByteLen, unsigned char *output, size_t outputByteLen, const unsigned char *customization, size_t customByteLen);
+int KangarooTwelve(const unsigned char *input, size_t inputByteLen, unsigned char *output, size_t outputByteLen, const unsigned char *customization, size_t customByteLen, int securityLevel);
 
 /**
   * Function to initialize a KangarooTwelve instance.
@@ -55,7 +57,7 @@ int KangarooTwelve(const unsigned char *input, size_t inputByteLen, unsigned cha
   *                         or 0 for an arbitrarily-long output.
   * @return 0 if successful, 1 otherwise.
   */
-int KangarooTwelve_Initialize(KangarooTwelve_Instance *ktInstance, size_t outputByteLen);
+int KangarooTwelve_Initialize(KangarooTwelve_Instance *ktInstance, size_t outputByteLen, int securityLevel);
 
 /**
   * Function to give input data to be absorbed.
@@ -64,7 +66,7 @@ int KangarooTwelve_Initialize(KangarooTwelve_Instance *ktInstance, size_t output
   * @param  inputByteLen    The number of bytes provided in the input message data.
   * @return 0 if successful, 1 otherwise.
   */
-int KangarooTwelve_Update(KangarooTwelve_Instance *ktInstance, const unsigned char *input, size_t inputByteLen);
+int KangarooTwelve_Update(KangarooTwelve_Instance *ktInstance, const unsigned char *input, size_t inputByteLen, int securityLevel);
 
 /**
   * Function to call after all the input message has been input, and to get
@@ -79,7 +81,7 @@ int KangarooTwelve_Update(KangarooTwelve_Instance *ktInstance, const unsigned ch
   * @param  customByteLen   The length of the customization string in bytes.
   * @return 0 if successful, 1 otherwise.
   */
-int KangarooTwelve_Final(KangarooTwelve_Instance *ktInstance, unsigned char *output, const unsigned char *customization, size_t customByteLen);
+int KangarooTwelve_Final(KangarooTwelve_Instance *ktInstance, unsigned char *output, const unsigned char *customization, size_t customByteLen, int securityLevel);
 
 /**
   * Function to squeeze output data.

--- a/lib/KangarooTwelve.h
+++ b/lib/KangarooTwelve.h
@@ -52,6 +52,16 @@ typedef struct KangarooTwelve_InstanceStruct {
 int KangarooTwelve(const unsigned char *input, size_t inputByteLen, unsigned char *output, size_t outputByteLen, const unsigned char *customization, size_t customByteLen, int securityLevel);
 
 /**
+ * Wrapper around `KangarooTwelve` to use the 128-bit security level.
+*/
+int KT128(const unsigned char *input, size_t inputByteLen, unsigned char *output, size_t outputByteLen, const unsigned char *customization, size_t customByteLen);
+
+/**
+ * Wrapper around `KangarooTwelve` to use the 256-bit security level.
+*/
+int KT256(const unsigned char *input, size_t inputByteLen, unsigned char *output, size_t outputByteLen, const unsigned char *customization, size_t customByteLen);
+
+/**
   * Function to initialize a KangarooTwelve instance.
   * @param  ktInstance      Pointer to the instance to be initialized.
   * @param  outputByteLen   The desired number of output bytes,

--- a/lib/KangarooTwelve.h
+++ b/lib/KangarooTwelve.h
@@ -22,8 +22,6 @@ http://creativecommons.org/publicdomain/zero/1.0/
 #include "align.h"
 #include "KeccakP-1600-SnP.h"
 
-// TODO: add the `securityLevel` parameter to the documentation comments
-
 typedef struct TurboSHAKE_InstanceStruct {
     uint8_t state[KeccakP1600_stateSizeInBytes];
     unsigned int rate;
@@ -48,6 +46,7 @@ typedef struct KangarooTwelve_InstanceStruct {
   * @param  outputByteLen   The desired number of output bytes.
   * @param  customization   Pointer to the customization string (C).
   * @param  customByteLen   The length of the customization string in bytes.
+  * @param  securityLevel   The desired security level (128 bits or 256 bits).
   * @return 0 if successful, 1 otherwise.
   */
 int KangarooTwelve(const unsigned char *input, size_t inputByteLen, unsigned char *output, size_t outputByteLen, const unsigned char *customization, size_t customByteLen, int securityLevel);
@@ -57,6 +56,7 @@ int KangarooTwelve(const unsigned char *input, size_t inputByteLen, unsigned cha
   * @param  ktInstance      Pointer to the instance to be initialized.
   * @param  outputByteLen   The desired number of output bytes,
   *                         or 0 for an arbitrarily-long output.
+  * @param  securityLevel   The desired security level (128 bits or 256 bits).
   * @return 0 if successful, 1 otherwise.
   */
 int KangarooTwelve_Initialize(KangarooTwelve_Instance *ktInstance, size_t outputByteLen, int securityLevel);

--- a/lib/KangarooTwelve.h
+++ b/lib/KangarooTwelve.h
@@ -46,10 +46,10 @@ typedef struct KangarooTwelve_InstanceStruct {
   * @param  outputByteLen   The desired number of output bytes.
   * @param  customization   Pointer to the customization string (C).
   * @param  customByteLen   The length of the customization string in bytes.
-  * @param  securityLevel   The desired security level (128 bits or 256 bits).
+  * @param  securityLevel   The desired security strength level (128 bits or 256 bits).
   * @return 0 if successful, 1 otherwise.
   */
-int KangarooTwelve(const unsigned char *input, size_t inputByteLen, unsigned char *output, size_t outputByteLen, const unsigned char *customization, size_t customByteLen, int securityLevel);
+int KangarooTwelve(int securityLevel, const unsigned char *input, size_t inputByteLen, unsigned char *output, size_t outputByteLen, const unsigned char *customization, size_t customByteLen);
 
 /**
  * Wrapper around `KangarooTwelve` to use the 128-bit security level.
@@ -64,18 +64,18 @@ int KT256(const unsigned char *input, size_t inputByteLen, unsigned char *output
 /**
   * Function to initialize a KangarooTwelve instance.
   * @param  ktInstance      Pointer to the instance to be initialized.
+  * @param  securityLevel   The desired security strength level (128 bits or 256 bits).
   * @param  outputByteLen   The desired number of output bytes,
   *                         or 0 for an arbitrarily-long output.
-  * @param  securityLevel   The desired security level (128 bits or 256 bits).
   * @return 0 if successful, 1 otherwise.
   */
-int KangarooTwelve_Initialize(KangarooTwelve_Instance *ktInstance, size_t outputByteLen, int securityLevel);
+int KangarooTwelve_Initialize(KangarooTwelve_Instance *ktInstance, int securityLevel, size_t outputByteLen);
 
 #define KT128_Initialize(instance, outputByteLen) \
-    KangarooTwelve_Initialize((instance), (outputByteLen), 128);
+    KangarooTwelve_Initialize((instance), 128, (outputByteLen));
 
 #define KT256_Initialize(instance, outputByteLen) \
-    KangarooTwelve_Initialize((instance), (outputByteLen), 256);
+    KangarooTwelve_Initialize((instance), 256, (outputByteLen));
 
 /**
   * Function to give input data to be absorbed.

--- a/lib/KangarooTwelve.h
+++ b/lib/KangarooTwelve.h
@@ -74,7 +74,7 @@ int KangarooTwelve_Initialize(KangarooTwelve_Instance *ktInstance, size_t output
   * @param  inputByteLen    The number of bytes provided in the input message data.
   * @return 0 if successful, 1 otherwise.
   */
-int KangarooTwelve_Update(KangarooTwelve_Instance *ktInstance, const unsigned char *input, size_t inputByteLen, int securityLevel);
+int KangarooTwelve_Update(KangarooTwelve_Instance *ktInstance, const unsigned char *input, size_t inputByteLen);
 
 /**
   * Function to call after all the input message has been input, and to get
@@ -89,7 +89,7 @@ int KangarooTwelve_Update(KangarooTwelve_Instance *ktInstance, const unsigned ch
   * @param  customByteLen   The length of the customization string in bytes.
   * @return 0 if successful, 1 otherwise.
   */
-int KangarooTwelve_Final(KangarooTwelve_Instance *ktInstance, unsigned char *output, const unsigned char *customization, size_t customByteLen, int securityLevel);
+int KangarooTwelve_Final(KangarooTwelve_Instance *ktInstance, unsigned char *output, const unsigned char *customization, size_t customByteLen);
 
 /**
   * Function to squeeze output data.

--- a/lib/Optimized64/KeccakP-1600-AVX512-plainC.c
+++ b/lib/Optimized64/KeccakP-1600-AVX512-plainC.c
@@ -240,7 +240,7 @@ size_t KeccakP1600_AVX512_12rounds_FastLoop_Absorb(void *state, unsigned int lan
         #undef laneCount
         copyToState(stateAsLanes);
     } else if (laneCount == 17) {
-        // TODO: this case was untested.
+        // TODO: further optimization needed for this case, laneCount == 17.
         while(dataByteLen >= laneCount*8) {
             KeccakP1600_AddBytes(state, data, 0, laneCount*8);
             KeccakP1600_Permute_12rounds(state);

--- a/lib/Optimized64/KeccakP-1600-AVX512-plainC.c
+++ b/lib/Optimized64/KeccakP-1600-AVX512-plainC.c
@@ -213,7 +213,6 @@ void KeccakP1600_AVX512_Permute_12rounds(void *state)
 /* ---------------------------------------------------------------- */
 
 #include <assert.h>
-#include <stdio.h>
 
 size_t KeccakP1600_AVX512_12rounds_FastLoop_Absorb(void *state, unsigned int laneCount, const unsigned char *data, size_t dataByteLen)
 {
@@ -226,6 +225,7 @@ size_t KeccakP1600_AVX512_12rounds_FastLoop_Absorb(void *state, unsigned int lan
     uint64_t *inDataAsLanes = (uint64_t*)data;
 
     if (laneCount == 21) {
+        #define laneCount 21
         copyFromState(stateAsLanes);
         while(dataByteLen >= 21*8) {
             Baeiou = XOR(Baeiou, LOAD_Plane(inDataAsLanes+ 0));
@@ -237,8 +237,10 @@ size_t KeccakP1600_AVX512_12rounds_FastLoop_Absorb(void *state, unsigned int lan
             inDataAsLanes += 21;
             dataByteLen -= 21*8;
         }
+        #undef laneCount
         copyToState(stateAsLanes);
     } else if (laneCount == 17) {
+        // TODO: hardcode `laneCount` for 17?
         while(dataByteLen >= laneCount*8) {
             KeccakP1600_AddBytes(state, data, 0, laneCount*8);
             KeccakP1600_Permute_12rounds(state);

--- a/lib/Optimized64/KeccakP-1600-AVX512-plainC.c
+++ b/lib/Optimized64/KeccakP-1600-AVX512-plainC.c
@@ -240,7 +240,7 @@ size_t KeccakP1600_AVX512_12rounds_FastLoop_Absorb(void *state, unsigned int lan
         #undef laneCount
         copyToState(stateAsLanes);
     } else if (laneCount == 17) {
-        // TODO: hardcode `laneCount` for 17?
+        // TODO: this case was untested.
         while(dataByteLen >= laneCount*8) {
             KeccakP1600_AddBytes(state, data, 0, laneCount*8);
             KeccakP1600_Permute_12rounds(state);

--- a/lib/Optimized64/KeccakP-1600-AVX512-plainC.c
+++ b/lib/Optimized64/KeccakP-1600-AVX512-plainC.c
@@ -213,10 +213,13 @@ void KeccakP1600_AVX512_Permute_12rounds(void *state)
 /* ---------------------------------------------------------------- */
 
 #include <assert.h>
+#include <stdio.h>
 
 size_t KeccakP1600_AVX512_12rounds_FastLoop_Absorb(void *state, unsigned int laneCount, const unsigned char *data, size_t dataByteLen)
 {
     size_t originalDataByteLen = dataByteLen;
+
+    printf("KeccakP1600_AVX512_12rounds_FastLoop_Absorb\n");
 
     assert(laneCount == 21);
 

--- a/lib/Optimized64/KeccakP-1600-opt64.c
+++ b/lib/Optimized64/KeccakP-1600-opt64.c
@@ -973,7 +973,6 @@ void KeccakP1600_opt64_ExtractBytes(const void *state, unsigned char *data, unsi
   ((x & 0x00000000000000ffull) << 56))
 #endif
 
-#define addInput(X, input, laneCount) \
 #define addInput21(X, input, laneCount) \
     if (laneCount == 21) { \
         X##ba ^= HTOLE64(input[ 0]); \

--- a/lib/Optimized64/KeccakP-1600-opt64.c
+++ b/lib/Optimized64/KeccakP-1600-opt64.c
@@ -974,6 +974,7 @@ void KeccakP1600_opt64_ExtractBytes(const void *state, unsigned char *data, unsi
 #endif
 
 #define addInput(X, input, laneCount) \
+#define addInput21(X, input, laneCount) \
     if (laneCount == 21) { \
         X##ba ^= HTOLE64(input[ 0]); \
         X##be ^= HTOLE64(input[ 1]); \
@@ -998,6 +999,27 @@ void KeccakP1600_opt64_ExtractBytes(const void *state, unsigned char *data, unsi
         X##sa ^= HTOLE64(input[20]); \
     } \
 
+#define addInput17(X, input, laneCount) \
+    if (laneCount == 17) { \
+        X##ba ^= HTOLE64(input[ 0]); \
+        X##be ^= HTOLE64(input[ 1]); \
+        X##bi ^= HTOLE64(input[ 2]); \
+        X##bo ^= HTOLE64(input[ 3]); \
+        X##bu ^= HTOLE64(input[ 4]); \
+        X##ga ^= HTOLE64(input[ 5]); \
+        X##ge ^= HTOLE64(input[ 6]); \
+        X##gi ^= HTOLE64(input[ 7]); \
+        X##go ^= HTOLE64(input[ 8]); \
+        X##gu ^= HTOLE64(input[ 9]); \
+        X##ka ^= HTOLE64(input[10]); \
+        X##ke ^= HTOLE64(input[11]); \
+        X##ki ^= HTOLE64(input[12]); \
+        X##ko ^= HTOLE64(input[13]); \
+        X##ku ^= HTOLE64(input[14]); \
+        X##ma ^= HTOLE64(input[15]); \
+        X##me ^= HTOLE64(input[16]); \
+    } \
+
 #include <assert.h>
 
 size_t KeccakP1600_opt64_12rounds_FastLoop_Absorb(void *state, unsigned int laneCount, const unsigned char *data, size_t dataByteLen)
@@ -1016,19 +1038,21 @@ size_t KeccakP1600_opt64_12rounds_FastLoop_Absorb(void *state, unsigned int lane
     if (laneCount == 21) {
         copyFromState(A, stateAsLanes)
         while(dataByteLen >= laneCount*8) {
-            addInput(A, inDataAsLanes, laneCount)
+            addInput21(A, inDataAsLanes, laneCount)
             rounds12
             inDataAsLanes += laneCount;
             dataByteLen -= laneCount*8;
         }
         copyToState(stateAsLanes, A)
     } else if (laneCount == 17) {
+        copyFromState(A, stateAsLanes)
         while(dataByteLen >= laneCount*8) {
-            KeccakP1600_AddBytes(state, data, 0, laneCount*8);
-            KeccakP1600_Permute_12rounds(state);
-            data += laneCount*8;
+            addInput17(A, inDataAsLanes, laneCount)
+            rounds12
+            inDataAsLanes += laneCount;
             dataByteLen -= laneCount*8;
         }
+        copyToState(stateAsLanes, A)
     }
     
     return originalDataByteLen - dataByteLen;

--- a/lib/Optimized64/KeccakP-1600-opt64.c
+++ b/lib/Optimized64/KeccakP-1600-opt64.c
@@ -999,10 +999,12 @@ void KeccakP1600_opt64_ExtractBytes(const void *state, unsigned char *data, unsi
     } \
 
 #include <assert.h>
+#include <stdio.h>
 
 size_t KeccakP1600_opt64_12rounds_FastLoop_Absorb(void *state, unsigned int laneCount, const unsigned char *data, size_t dataByteLen)
 {
     size_t originalDataByteLen = dataByteLen;
+
     declareABCDE
     #ifndef KeccakP1600_opt64_fullUnrolling
     unsigned int i;
@@ -1010,9 +1012,10 @@ size_t KeccakP1600_opt64_12rounds_FastLoop_Absorb(void *state, unsigned int lane
     uint64_t *stateAsLanes = (uint64_t*)state;
     uint64_t *inDataAsLanes = (uint64_t*)data;
 
-    assert(laneCount == 21);
+    // note: for KT256, laneCount will be 17
+    // assert(laneCount == 21);
 
-    #define laneCount 21
+    // #define laneCount 21
     copyFromState(A, stateAsLanes)
     while(dataByteLen >= laneCount*8) {
         addInput(A, inDataAsLanes, laneCount)
@@ -1020,7 +1023,7 @@ size_t KeccakP1600_opt64_12rounds_FastLoop_Absorb(void *state, unsigned int lane
         inDataAsLanes += laneCount;
         dataByteLen -= laneCount*8;
     }
-    #undef laneCount
+    // #undef laneCount
     copyToState(stateAsLanes, A)
     return originalDataByteLen - dataByteLen;
 }

--- a/lib/Optimized64/KeccakP-1600-runtimeDispatch.c
+++ b/lib/Optimized64/KeccakP-1600-runtimeDispatch.c
@@ -88,8 +88,8 @@ void KT256_Process2Leaves(const unsigned char *input, unsigned char *output)
 void KT128_AVX2_Process4Leaves(const unsigned char *input, unsigned char *output);
 void KT128_AVX512_Process4Leaves(const unsigned char *input, unsigned char *output);
 
-void KT128_AVX2_Process8Leaves(const unsigned char *input, unsigned char *output);
-void KT128_AVX512_Process8Leaves(const unsigned char *input, unsigned char *output);
+void KT256_AVX2_Process4Leaves(const unsigned char *input, unsigned char *output);
+void KT256_AVX512_Process4Leaves(const unsigned char *input, unsigned char *output);
 
 int KeccakP1600times4_IsAvailable()
 {
@@ -122,9 +122,9 @@ void KT128_Process4Leaves(const unsigned char *input, unsigned char *output)
 void KT256_Process4Leaves(const unsigned char *input, unsigned char *output)
 {
     if (K12_enableAVX512) {
-        KT128_AVX512_Process4Leaves(input, output);
+        KT256_AVX512_Process4Leaves(input, output);
     } else if (K12_enableAVX2) {
-        KT128_AVX2_Process4Leaves(input, output);
+        KT256_AVX2_Process4Leaves(input, output);
     }
 }
 

--- a/lib/Optimized64/KeccakP-1600-runtimeDispatch.c
+++ b/lib/Optimized64/KeccakP-1600-runtimeDispatch.c
@@ -41,8 +41,8 @@ int K12_enableAVX512 = 0;
 
 /* ---------------------------------------------------------------- */
 
-void KangarooTwelve_SSSE3_Process2Leaves(const unsigned char *input, unsigned char *output);
-void KangarooTwelve_AVX512_Process2Leaves(const unsigned char *input, unsigned char *output);
+void KT128_SSSE3_Process2Leaves(const unsigned char *input, unsigned char *output);
+void KT128_AVX512_Process2Leaves(const unsigned char *input, unsigned char *output);
 
 int KeccakP1600times2_IsAvailable()
 {
@@ -63,18 +63,18 @@ const char * KeccakP1600times2_GetImplementation()
     }
 }
 
-void KangarooTwelve_Process2Leaves(const unsigned char *input, unsigned char *output)
+void KT128_Process2Leaves(const unsigned char *input, unsigned char *output)
 {
     if (K12_enableAVX512) {
-        KangarooTwelve_AVX512_Process2Leaves(input, output);
+        KT128_AVX512_Process2Leaves(input, output);
     } else if (K12_enableSSSE3) {
-        KangarooTwelve_SSSE3_Process2Leaves(input, output);
+        KT128_SSSE3_Process2Leaves(input, output);
     }
 }
 
 
-void KangarooTwelve_AVX2_Process4Leaves(const unsigned char *input, unsigned char *output);
-void KangarooTwelve_AVX512_Process4Leaves(const unsigned char *input, unsigned char *output);
+void KT128_AVX2_Process4Leaves(const unsigned char *input, unsigned char *output);
+void KT128_AVX512_Process4Leaves(const unsigned char *input, unsigned char *output);
 
 int KeccakP1600times4_IsAvailable()
 {
@@ -95,17 +95,17 @@ const char * KeccakP1600times4_GetImplementation()
     }
 }
 
-void KangarooTwelve_Process4Leaves(const unsigned char *input, unsigned char *output)
+void KT128_Process4Leaves(const unsigned char *input, unsigned char *output)
 {
     if (K12_enableAVX512) {
-        KangarooTwelve_AVX512_Process4Leaves(input, output);
+        KT128_AVX512_Process4Leaves(input, output);
     } else if (K12_enableAVX2) {
-        KangarooTwelve_AVX2_Process4Leaves(input, output);
+        KT128_AVX2_Process4Leaves(input, output);
     }
 }
 
 
-void KangarooTwelve_AVX512_Process8Leaves(const unsigned char *input, unsigned char *output);
+void KT128_AVX512_Process8Leaves(const unsigned char *input, unsigned char *output);
 
 int KeccakP1600times8_IsAvailable()
 {
@@ -123,10 +123,10 @@ const char * KeccakP1600times8_GetImplementation()
     }
 }
 
-void KangarooTwelve_Process8Leaves(const unsigned char *input, unsigned char *output)
+void KT128_Process8Leaves(const unsigned char *input, unsigned char *output)
 {
     if (K12_enableAVX512)
-        KangarooTwelve_AVX512_Process8Leaves(input, output);
+        KT128_AVX512_Process8Leaves(input, output);
 }
 
 #endif  // KeccakP1600_disableParallelism

--- a/lib/Optimized64/KeccakP-1600-runtimeDispatch.c
+++ b/lib/Optimized64/KeccakP-1600-runtimeDispatch.c
@@ -44,6 +44,9 @@ int K12_enableAVX512 = 0;
 void KT128_SSSE3_Process2Leaves(const unsigned char *input, unsigned char *output);
 void KT128_AVX512_Process2Leaves(const unsigned char *input, unsigned char *output);
 
+void KT256_SSSE3_Process2Leaves(const unsigned char *input, unsigned char *output);
+void KT256_AVX512_Process2Leaves(const unsigned char *input, unsigned char *output);
+
 int KeccakP1600times2_IsAvailable()
 {
     int result = 0;
@@ -72,9 +75,21 @@ void KT128_Process2Leaves(const unsigned char *input, unsigned char *output)
     }
 }
 
+void KT256_Process2Leaves(const unsigned char *input, unsigned char *output)
+{
+    if (K12_enableAVX512) {
+        KT256_AVX512_Process2Leaves(input, output);
+    } else if (K12_enableSSSE3) {
+        KT256_SSSE3_Process2Leaves(input, output);
+    }
+}
+
 
 void KT128_AVX2_Process4Leaves(const unsigned char *input, unsigned char *output);
 void KT128_AVX512_Process4Leaves(const unsigned char *input, unsigned char *output);
+
+void KT128_AVX2_Process8Leaves(const unsigned char *input, unsigned char *output);
+void KT128_AVX512_Process8Leaves(const unsigned char *input, unsigned char *output);
 
 int KeccakP1600times4_IsAvailable()
 {
@@ -104,8 +119,18 @@ void KT128_Process4Leaves(const unsigned char *input, unsigned char *output)
     }
 }
 
+void KT256_Process4Leaves(const unsigned char *input, unsigned char *output)
+{
+    if (K12_enableAVX512) {
+        KT128_AVX512_Process4Leaves(input, output);
+    } else if (K12_enableAVX2) {
+        KT128_AVX2_Process4Leaves(input, output);
+    }
+}
 
 void KT128_AVX512_Process8Leaves(const unsigned char *input, unsigned char *output);
+
+void KT256_AVX512_Process8Leaves(const unsigned char *input, unsigned char *output);
 
 int KeccakP1600times8_IsAvailable()
 {
@@ -127,6 +152,12 @@ void KT128_Process8Leaves(const unsigned char *input, unsigned char *output)
 {
     if (K12_enableAVX512)
         KT128_AVX512_Process8Leaves(input, output);
+}
+
+void KT256_Process8Leaves(const unsigned char *input, unsigned char *output)
+{
+    if (K12_enableAVX512)
+        KT256_AVX512_Process8Leaves(input, output);
 }
 
 #endif  // KeccakP1600_disableParallelism

--- a/lib/Optimized64/KeccakP-1600-timesN-AVX2.c
+++ b/lib/Optimized64/KeccakP-1600-timesN-AVX2.c
@@ -363,9 +363,12 @@ static ALIGN(AVX2alignment) const uint64_t KeccakP1600RoundConstants[24] = {
     XOReq256(X##ku, LOAD4_64((data3)[14], (data2)[14], (data1)[14], (data0)[14])); \
     XOReq256(X##ma, LOAD4_64((data3)[15], (data2)[15], (data1)[15], (data0)[15])); \
 
-#define XORdata21(X, data0, data1, data2, data3) \
+#define XORdata17(X, data0, data1, data2, data3) \
     XORdata16(X, data0, data1, data2, data3) \
     XOReq256(X##me, LOAD4_64((data3)[16], (data2)[16], (data1)[16], (data0)[16])); \
+
+#define XORdata21(X, data0, data1, data2, data3) \
+    XORdata17(X, data0, data1, data2, data3) \
     XOReq256(X##mi, LOAD4_64((data3)[17], (data2)[17], (data1)[17], (data0)[17])); \
     XOReq256(X##mo, LOAD4_64((data3)[18], (data2)[18], (data1)[18], (data0)[18])); \
     XOReq256(X##mu, LOAD4_64((data3)[19], (data2)[19], (data1)[19], (data0)[19])); \
@@ -430,7 +433,7 @@ void KT256_AVX2_Process4Leaves(const unsigned char *input, unsigned char *output
     initializeState(A);
 
     for(j = 0; j < (chunkSize - KT256_rateInBytes); j += KT256_rateInBytes) {
-        XORdata21(A, (const uint64_t *)input, (const uint64_t *)(input+chunkSize), (const uint64_t *)(input+2*chunkSize), (const uint64_t *)(input+3*chunkSize));
+        XORdata17(A, (const uint64_t *)input, (const uint64_t *)(input+chunkSize), (const uint64_t *)(input+2*chunkSize), (const uint64_t *)(input+3*chunkSize));
         rounds12
         input += KT256_rateInBytes;
     }
@@ -440,6 +443,7 @@ void KT256_AVX2_Process4Leaves(const unsigned char *input, unsigned char *output
     XOReq256(Ago, CONST256_64(0x8000000000000000ULL));
 
     {
+        // TODO: extract the chaining value:
         // 4 leaves, and 512 bits for each -> 2048 bits = 8 * 256 bits
         // so output will have to fill output[0] to output[224]
     }

--- a/lib/Optimized64/KeccakP-1600-timesN-AVX2.c
+++ b/lib/Optimized64/KeccakP-1600-timesN-AVX2.c
@@ -393,7 +393,7 @@ static ALIGN(AVX2alignment) const uint64_t KeccakP1600RoundConstants[24] = {
 #define KT128_rateInBytes (21*8)
 #define KT256_rateInBytes (17*8)
 
-void KangarooTwelve_AVX2_Process4Leaves(const unsigned char *input, unsigned char *output)
+void KT128_AVX2_Process4Leaves(const unsigned char *input, unsigned char *output)
 {
     declareABCDE
     unsigned int j;

--- a/lib/Optimized64/KeccakP-1600-timesN-AVX2.c
+++ b/lib/Optimized64/KeccakP-1600-timesN-AVX2.c
@@ -440,11 +440,28 @@ void KT256_AVX2_Process4Leaves(const unsigned char *input, unsigned char *output
 
     XORdata4(A, (const uint64_t *)input, (const uint64_t *)(input+chunkSize), (const uint64_t *)(input+2*chunkSize), (const uint64_t *)(input+3*chunkSize));
     XOReq256(Abu, CONST256_64(0x0BULL));
-    XOReq256(Ago, CONST256_64(0x8000000000000000ULL));
+    XOReq256(Ame, CONST256_64(0x8000000000000000ULL));
+    rounds12
 
     {
-        // TODO: extract the chaining value:
-        // 4 leaves, and 512 bits for each -> 2048 bits = 8 * 256 bits
-        // so output will have to fill output[0] to output[224]
+        __m256i lanesL01, lanesL23, lanesH01, lanesH23;
+
+        lanesL01 = UNPACKL( Aba, Abe );
+        lanesH01 = UNPACKH( Aba, Abe );
+        lanesL23 = UNPACKL( Abi, Abo );
+        lanesH23 = UNPACKH( Abi, Abo );
+        STORE256u( output[  0], PERM128( lanesL01, lanesL23, 0x20 ) );
+        STORE256u( output[ 64], PERM128( lanesH01, lanesH23, 0x20 ) );
+        STORE256u( output[128], PERM128( lanesL01, lanesL23, 0x31 ) );
+        STORE256u( output[192], PERM128( lanesH01, lanesH23, 0x31 ) );
+
+        lanesL01 = UNPACKL( Abu, Aga );
+        lanesH01 = UNPACKH( Abu, Aga );
+        lanesL23 = UNPACKL( Age, Agi );
+        lanesH23 = UNPACKH( Age, Agi );
+        STORE256u( output[ 32], PERM128( lanesL01, lanesL23, 0x20 ) );
+        STORE256u( output[ 96], PERM128( lanesH01, lanesH23, 0x20 ) );
+        STORE256u( output[160], PERM128( lanesL01, lanesL23, 0x31 ) );
+        STORE256u( output[224], PERM128( lanesH01, lanesH23, 0x31 ) );
     }
 }

--- a/lib/Optimized64/KeccakP-1600-timesN-AVX512.c
+++ b/lib/Optimized64/KeccakP-1600-timesN-AVX512.c
@@ -465,17 +465,18 @@ void KT256_AVX512_Process4Leaves(const unsigned char *input, unsigned char *outp
     r6 = _mm512_shuffle_i32x4(t2, t6, 0xdd); \
     r7 = _mm512_shuffle_i32x4(t3, t7, 0xdd); \
 
-// TODO: verify if the XORdata4 is implemented correctly,
-//  namely, the call to `LoadAndTranspose8`, is it good?
 #define XORdata4(X, index, dataAsLanes) \
+    XOReq(X##ba, LOAD_GATHER8_64(index, (dataAsLanes) + 0)); \
+    XOReq(X##be, LOAD_GATHER8_64(index, (dataAsLanes) + 1)); \
+    XOReq(X##bi, LOAD_GATHER8_64(index, (dataAsLanes) + 2)); \
+    XOReq(X##bo, LOAD_GATHER8_64(index, (dataAsLanes) + 3)); \
+
+#define XORdata16(X, index, dataAsLanes) \
     LoadAndTranspose8(dataAsLanes, 0) \
     XOReq(X##ba, r0); \
     XOReq(X##be, r1); \
     XOReq(X##bi, r2); \
     XOReq(X##bo, r3); \
-
-#define XORdata16(X, index, dataAsLanes) \
-    XORdata4(X, index, dataAsLanes) \
     XOReq(X##bu, r4); \
     XOReq(X##ga, r5); \
     XOReq(X##ge, r6); \

--- a/lib/Optimized64/KeccakP-1600-timesN-AVX512.c
+++ b/lib/Optimized64/KeccakP-1600-timesN-AVX512.c
@@ -225,7 +225,7 @@ static ALIGN(AVX512alignment) const uint64_t KeccakP1600RoundConstants[24] = {
 #define KT128_rateInBytes (21*8)
 #define KT256_rateInBytes (17*8)
 
-void KangarooTwelve_AVX512_Process2Leaves(const unsigned char *input, unsigned char *output)
+void KT128_AVX512_Process2Leaves(const unsigned char *input, unsigned char *output)
 {
     KeccakP_DeclareVars(__m128i);
     unsigned int j;
@@ -340,7 +340,7 @@ void KT256_AVX512_Process2Leaves(const unsigned char *input, unsigned char *outp
     XOReq(X##mu, LOAD4_64((data3)[19], (data2)[19], (data1)[19], (data0)[19])); \
     XOReq(X##sa, LOAD4_64((data3)[20], (data2)[20], (data1)[20], (data0)[20])); \
 
-void KangarooTwelve_AVX512_Process4Leaves(const unsigned char *input, unsigned char *output)
+void KT128_AVX512_Process4Leaves(const unsigned char *input, unsigned char *output)
 {
     KeccakP_DeclareVars(__m256i);
     unsigned int j;
@@ -501,7 +501,7 @@ void KT256_AVX512_Process4Leaves(const unsigned char *input, unsigned char *outp
     XOReq(X##mu, LOAD_GATHER8_64(index, (dataAsLanes) + 19)); \
     XOReq(X##sa, LOAD_GATHER8_64(index, (dataAsLanes) + 20)); \
 
-void KangarooTwelve_AVX512_Process8Leaves(const unsigned char *input, unsigned char *output)
+void KT128_AVX512_Process8Leaves(const unsigned char *input, unsigned char *output)
 {
     KeccakP_DeclareVars(__m512i);
     unsigned int j;

--- a/lib/Optimized64/KeccakP-1600-timesN-SSSE3.c
+++ b/lib/Optimized64/KeccakP-1600-timesN-SSSE3.c
@@ -410,7 +410,7 @@ static ALIGN(SSSE3alignment) const uint64_t KeccakP1600RoundConstants[24] = {
 #define chunkSize 8192
 #define rateInBytes (21*8)
 
-void KangarooTwelve_SSSE3_Process2Leaves(const unsigned char *input, unsigned char *output)
+void KT128_SSSE3_Process2Leaves(const unsigned char *input, unsigned char *output)
 {
     declareABCDE
     #ifndef KeccakP1600times2_SSSE3_fullUnrolling
@@ -436,3 +436,5 @@ void KangarooTwelve_SSSE3_Process2Leaves(const unsigned char *input, unsigned ch
     STORE128u( *(__m128i*)&(output[32]), UNPACKH( Aba, Abe ) );
     STORE128u( *(__m128i*)&(output[48]), UNPACKH( Abi, Abo ) );
 }
+
+// TODO: add KT256_SSE3_Process2Leaves

--- a/lib/Optimized64/KeccakP-1600-timesN-SSSE3.c
+++ b/lib/Optimized64/KeccakP-1600-timesN-SSSE3.c
@@ -465,7 +465,7 @@ void KT256_SSSE3_Process2Leaves(const unsigned char *input, unsigned char *outpu
 
     XORdata4(A, (const uint64_t *)input, (const uint64_t *)(input+chunkSize));
     XOReq128(Abu, _mm_set1_epi64x(0x0BULL));
-    XOReq128(Ago, _mm_set1_epi64x(0x8000000000000000ULL));
+    XOReq128(Ame, _mm_set1_epi64x(0x8000000000000000ULL));
     rounds12
 
     STORE128u( *(__m128i*)&(output[ 0]), UNPACKL( Aba, Abe ) );

--- a/tests/main.c
+++ b/tests/main.c
@@ -43,7 +43,7 @@ void bench1GB()
     #define INPUT_SIZE 1000000000
     static ALIGN(64) unsigned char input[INPUT_SIZE];
     static ALIGN(64) unsigned char output[32];
-    KangarooTwelve(input, INPUT_SIZE, output, 32, 0, 0);
+    KT128(input, INPUT_SIZE, output, 32, 0, 0);
     #undef INPUT_SIZE
 }
 #endif


### PR DESCRIPTION
This PR has as a goal to implement the new _KT256_ in the K12 package. Please refer to [the draft here](https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-kangarootwelve) for more information and context on _KT256_ vs the current _KT128_ functions.

A list of todos is left in the code, namely:
- [x] fix the call to `KeccakP1600_12rounds_FastLoop_Absorb` in `TurboSHAKE128_Absorb`
- [x] replace the static value `K12_capacityInBytes` with a dynamic one
- [x] rename `TurboSHAKE128_Suffix` to `TurboSHAKE_Suffix` and related refactors
- [x] update the documentation in `KangarooTwelve.h`
- adapt `ProcessLeaves` for _KT256_
  - [x] complete `KT256_AVX2_Process4Leaves`
  - [x] complete `KT256_AVX512_Process4Leaves`
  - [x] adapt `ProcessLeaves` to conditionally call `KT128##Parallellism##Leaves` or `KT256##Parallellism##Leaves`