### PR TITLE
Add multi-threads support to K12

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -70,6 +70,13 @@ http://creativecommons.org/publicdomain/zero/1.0/
         <h>lib/align.h</h>
         <c>lib/KangarooTwelve.c</c>
         <h>lib/KangarooTwelve.h</h>
+        <h>lib/KT-threadpool.h</h>
+        <c>lib/KT-threadpool.c</c>
+        <c>lib/KT-threadpool-pthread.c</c>
+        <c>lib/KT-threadpool-sequential.c</c>
+        <c>lib/KangarooTwelve-threading.c</c>
+        <h>lib/KangarooTwelve-threading.h</h>
+        <gcc>-pthread</gcc>
     </fragment>
 
     <!-- For the name of the targets, please see the end of this file. -->

--- a/lib/KT-threadpool-pthread.c
+++ b/lib/KT-threadpool-pthread.c
@@ -1,0 +1,295 @@
+/*
+K12 based on the eXtended Keccak Code Package (XKCP)
+https://github.com/XKCP/XKCP
+
+Thread pool implementation using POSIX threads (pthreads).
+
+To the extent possible under law, the implementer has waived all copyright
+and related or neighboring rights to the source code in this file.
+http://creativecommons.org/publicdomain/zero/1.0/
+*/
+
+#include "KT-threadpool.h"
+#include <stdlib.h>
+#include <string.h>
+
+/* Only compile pthread backend if pthreads are available */
+#if defined(_POSIX_THREADS) || defined(__unix__) || defined(__unix) || \
+    (defined(__APPLE__) && defined(__MACH__)) || defined(__linux__) || \
+    defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+
+#include <pthread.h>
+
+#define MAX_THREADS 64
+#define MAX_JOBS 256
+
+/* Job structure */
+typedef struct {
+    void (*work_fn)(void*);
+    void* work_data;
+} Job;
+
+/* Thread pool context */
+typedef struct {
+    pthread_t* threads;
+    int num_threads;
+
+    /* Job queue */
+    Job job_queue[MAX_JOBS];
+    int job_count;
+    int jobs_grabbed;    /* Number of jobs grabbed by workers */
+    int jobs_finished;   /* Number of jobs actually completed */
+
+    /* Synchronization */
+    pthread_mutex_t mutex;
+    pthread_cond_t work_available;
+    pthread_cond_t work_complete;
+
+    /* Thread IDs for passing to worker threads */
+    int* thread_ids;
+
+    /* Lifecycle */
+    int shutdown;
+} PthreadPool;
+
+/* Worker thread function */
+static void* worker_thread(void* arg)
+{
+    PthreadPool* pool = (PthreadPool*)arg;
+
+    while (1) {
+        pthread_mutex_lock(&pool->mutex);
+
+        /* Wait for work or shutdown */
+        while (!pool->shutdown && pool->jobs_grabbed >= pool->job_count) {
+            pthread_cond_wait(&pool->work_available, &pool->mutex);
+        }
+
+        if (pool->shutdown) {
+            pthread_mutex_unlock(&pool->mutex);
+            break;
+        }
+
+        /* Get next available job atomically */
+        Job job;
+        int has_job = 0;
+        if (pool->jobs_grabbed < pool->job_count) {
+            job = pool->job_queue[pool->jobs_grabbed];
+            pool->jobs_grabbed++;
+            has_job = 1;
+        }
+
+        pthread_mutex_unlock(&pool->mutex);
+
+        /* Execute job outside the lock */
+        if (has_job && job.work_fn) {
+            job.work_fn(job.work_data);
+
+            /* Mark job as finished */
+            pthread_mutex_lock(&pool->mutex);
+            pool->jobs_finished++;
+            if (pool->jobs_finished >= pool->job_count) {
+                pthread_cond_signal(&pool->work_complete);
+            }
+            pthread_mutex_unlock(&pool->mutex);
+        }
+    }
+
+    return NULL;
+}
+
+/* Create pthread pool */
+static void* pthread_create_pool(int num_threads)
+{
+    if (num_threads < 1 || num_threads > MAX_THREADS)
+        return NULL;
+
+    PthreadPool* pool = (PthreadPool*)malloc(sizeof(PthreadPool));
+    if (!pool)
+        return NULL;
+
+    memset(pool, 0, sizeof(PthreadPool));
+    pool->num_threads = num_threads;
+
+    /* Initialize synchronization primitives */
+    if (pthread_mutex_init(&pool->mutex, NULL) != 0) {
+        free(pool);
+        return NULL;
+    }
+
+    if (pthread_cond_init(&pool->work_available, NULL) != 0) {
+        pthread_mutex_destroy(&pool->mutex);
+        free(pool);
+        return NULL;
+    }
+
+    if (pthread_cond_init(&pool->work_complete, NULL) != 0) {
+        pthread_mutex_destroy(&pool->mutex);
+        pthread_cond_destroy(&pool->work_available);
+        free(pool);
+        return NULL;
+    }
+
+    /* Allocate thread array */
+    pool->threads = (pthread_t*)malloc(num_threads * sizeof(pthread_t));
+    if (!pool->threads) {
+        pthread_mutex_destroy(&pool->mutex);
+        pthread_cond_destroy(&pool->work_available);
+        pthread_cond_destroy(&pool->work_complete);
+        free(pool);
+        return NULL;
+    }
+
+    pool->thread_ids = (int*)malloc(num_threads * sizeof(int));
+    if (!pool->thread_ids) {
+        free(pool->threads);
+        pthread_mutex_destroy(&pool->mutex);
+        pthread_cond_destroy(&pool->work_available);
+        pthread_cond_destroy(&pool->work_complete);
+        free(pool);
+        return NULL;
+    }
+
+    /* Create worker threads */
+    pool->shutdown = 0;
+    pool->job_count = 0;
+    pool->jobs_grabbed = 0;
+    pool->jobs_finished = 0;
+
+    for (int i = 0; i < num_threads; i++) {
+        pool->thread_ids[i] = i;
+        if (pthread_create(&pool->threads[i], NULL, worker_thread, pool) != 0) {
+            /* Failed to create thread - clean up */
+            pool->shutdown = 1;
+            pthread_cond_broadcast(&pool->work_available);
+            for (int j = 0; j < i; j++) {
+                pthread_join(pool->threads[j], NULL);
+            }
+            free(pool->thread_ids);
+            free(pool->threads);
+            pthread_mutex_destroy(&pool->mutex);
+            pthread_cond_destroy(&pool->work_available);
+            pthread_cond_destroy(&pool->work_complete);
+            free(pool);
+            return NULL;
+        }
+    }
+
+    return pool;
+}
+
+/* Submit work to pthread pool */
+static int pthread_submit(void* pool_handle, void (*work_fn)(void*), void* work_data)
+{
+    PthreadPool* pool = (PthreadPool*)pool_handle;
+    if (!pool || !work_fn)
+        return 1;
+
+    pthread_mutex_lock(&pool->mutex);
+
+    if (pool->job_count >= MAX_JOBS) {
+        pthread_mutex_unlock(&pool->mutex);
+        return 1;  /* Job queue full */
+    }
+
+    pool->job_queue[pool->job_count].work_fn = work_fn;
+    pool->job_queue[pool->job_count].work_data = work_data;
+    pool->job_count++;
+
+    pthread_mutex_unlock(&pool->mutex);
+
+    return 0;
+}
+
+/* Wait for all work to complete */
+static void pthread_wait_all(void* pool_handle)
+{
+    PthreadPool* pool = (PthreadPool*)pool_handle;
+    if (!pool)
+        return;
+
+    pthread_mutex_lock(&pool->mutex);
+
+    /* Reset counters and wake up workers */
+    pool->jobs_grabbed = 0;
+    pool->jobs_finished = 0;
+    pthread_cond_broadcast(&pool->work_available);
+
+    /* Wait for all jobs to finish execution */
+    while (pool->jobs_finished < pool->job_count) {
+        pthread_cond_wait(&pool->work_complete, &pool->mutex);
+    }
+
+    /* Reset for next batch */
+    pool->job_count = 0;
+    pool->jobs_grabbed = 0;
+    pool->jobs_finished = 0;
+
+    pthread_mutex_unlock(&pool->mutex);
+}
+
+/* Destroy pthread pool */
+static void pthread_destroy(void* pool_handle)
+{
+    PthreadPool* pool = (PthreadPool*)pool_handle;
+    if (!pool)
+        return;
+
+    pthread_mutex_lock(&pool->mutex);
+    pool->shutdown = 1;
+    pthread_cond_broadcast(&pool->work_available);
+    pthread_mutex_unlock(&pool->mutex);
+
+    /* Wait for all threads to finish */
+    for (int i = 0; i < pool->num_threads; i++) {
+        pthread_join(pool->threads[i], NULL);
+    }
+
+    /* Cleanup */
+    free(pool->thread_ids);
+    free(pool->threads);
+    pthread_mutex_destroy(&pool->mutex);
+    pthread_cond_destroy(&pool->work_available);
+    pthread_cond_destroy(&pool->work_complete);
+    free(pool);
+}
+
+/* Export pthread backend API */
+const KT_ThreadPool_API KT_ThreadPool_Pthread = {
+    .min_input_size_for_threading = 2097152,  /* 2 MB default threshold */
+    .create = pthread_create_pool,
+    .submit = pthread_submit,
+    .wait_all = pthread_wait_all,
+    .destroy = pthread_destroy
+};
+
+#else /* !HAVE_PTHREADS */
+
+/* Pthread not available on this platform - provide stub */
+static void* pthread_stub_create(int num_threads) {
+    (void)num_threads;
+    return NULL;
+}
+
+static int pthread_stub_submit(void* pool, void (*work_fn)(void*), void* work_data) {
+    (void)pool; (void)work_fn; (void)work_data;
+    return 1;
+}
+
+static void pthread_stub_wait_all(void* pool) {
+    (void)pool;
+}
+
+static void pthread_stub_destroy(void* pool) {
+    (void)pool;
+}
+
+const KT_ThreadPool_API KT_ThreadPool_Pthread = {
+    .min_input_size_for_threading = 2097152,  /* 2 MB default threshold */
+    .create = pthread_stub_create,
+    .submit = pthread_stub_submit,
+    .wait_all = pthread_stub_wait_all,
+    .destroy = pthread_stub_destroy
+};
+
+#endif /* HAVE_PTHREADS */

--- a/lib/KT-threadpool-sequential.c
+++ b/lib/KT-threadpool-sequential.c
@@ -1,0 +1,101 @@
+/*
+K12 based on the eXtended Keccak Code Package (XKCP)
+https://github.com/XKCP/XKCP
+
+Sequential (no-threading) thread pool implementation.
+
+This backend executes work functions immediately in the calling thread,
+providing no actual parallelism. It serves as a portable fallback for
+platforms without threading support and is useful for testing/debugging.
+
+To the extent possible under law, the implementer has waived all copyright
+and related or neighboring rights to the source code in this file.
+http://creativecommons.org/publicdomain/zero/1.0/
+*/
+
+#include "KT-threadpool.h"
+#include <stdlib.h>
+
+#define MAX_JOBS 256
+
+/* Sequential pool context */
+typedef struct {
+    /* Job queue */
+    struct {
+        void (*work_fn)(void*);
+        void* work_data;
+    } jobs[MAX_JOBS];
+    int job_count;
+    int valid;  /* Marker to detect use-after-free */
+} SequentialPool;
+
+/* Create sequential pool */
+static void* sequential_create_pool(int num_threads)
+{
+    /* Ignore num_threads - we're always sequential */
+    (void)num_threads;
+
+    SequentialPool* pool = (SequentialPool*)malloc(sizeof(SequentialPool));
+    if (!pool)
+        return NULL;
+
+    pool->job_count = 0;
+    pool->valid = 0x12345678;  /* Magic number for validation */
+
+    return pool;
+}
+
+/* Submit work to sequential pool (just queue it) */
+static int sequential_submit(void* pool_handle, void (*work_fn)(void*), void* work_data)
+{
+    SequentialPool* pool = (SequentialPool*)pool_handle;
+    if (!pool || pool->valid != 0x12345678 || !work_fn)
+        return 1;
+
+    if (pool->job_count >= MAX_JOBS)
+        return 1;  /* Job queue full */
+
+    pool->jobs[pool->job_count].work_fn = work_fn;
+    pool->jobs[pool->job_count].work_data = work_data;
+    pool->job_count++;
+
+    return 0;
+}
+
+/* Wait for all work (execute queued jobs sequentially) */
+static void sequential_wait_all(void* pool_handle)
+{
+    SequentialPool* pool = (SequentialPool*)pool_handle;
+    if (!pool || pool->valid != 0x12345678)
+        return;
+
+    /* Execute all queued jobs sequentially */
+    for (int i = 0; i < pool->job_count; i++) {
+        if (pool->jobs[i].work_fn) {
+            pool->jobs[i].work_fn(pool->jobs[i].work_data);
+        }
+    }
+
+    /* Reset for next batch */
+    pool->job_count = 0;
+}
+
+/* Destroy sequential pool */
+static void sequential_destroy(void* pool_handle)
+{
+    SequentialPool* pool = (SequentialPool*)pool_handle;
+    if (!pool)
+        return;
+
+    pool->valid = 0;  /* Invalidate */
+    free(pool);
+}
+
+/* Export sequential backend API */
+const KT_ThreadPool_API KT_ThreadPool_Sequential = {
+    .min_input_size_for_threading = 2097152,  /* 2 MB default threshold */
+    .create = sequential_create_pool,
+    .submit = sequential_submit,
+    .wait_all = sequential_wait_all,
+    .destroy = sequential_destroy
+};

--- a/lib/KT-threadpool.c
+++ b/lib/KT-threadpool.c
@@ -1,0 +1,28 @@
+/*
+K12 based on the eXtended Keccak Code Package (XKCP)
+https://github.com/XKCP/XKCP
+
+Thread pool abstraction layer - common functions.
+
+To the extent possible under law, the implementer has waived all copyright
+and related or neighboring rights to the source code in this file.
+http://creativecommons.org/publicdomain/zero/1.0/
+*/
+
+#include "KT-threadpool.h"
+
+/* Detect pthread availability */
+#if defined(_POSIX_THREADS) || defined(__unix__) || defined(__unix) || \
+    (defined(__APPLE__) && defined(__MACH__)) || defined(__linux__) || \
+    defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__)
+#define HAVE_PTHREADS 1
+#endif
+
+const KT_ThreadPool_API* KT_ThreadPool_GetDefault(void)
+{
+#ifdef HAVE_PTHREADS
+    return &KT_ThreadPool_Pthread;
+#else
+    return &KT_ThreadPool_Sequential;
+#endif
+}

--- a/lib/KT-threadpool.h
+++ b/lib/KT-threadpool.h
@@ -1,0 +1,122 @@
+/*
+K12 based on the eXtended Keccak Code Package (XKCP)
+https://github.com/XKCP/XKCP
+
+Thread pool abstraction layer for portable threading support.
+
+This provides a simple, application-implementable thread pool API that allows
+KangarooTwelve to use custom threading implementations or fall back to
+sequential execution on platforms without threading support.
+
+To the extent possible under law, the implementer has waived all copyright
+and related or neighboring rights to the source code in this file.
+http://creativecommons.org/publicdomain/zero/1.0/
+*/
+
+#ifndef _KT_threadpool_h_
+#define _KT_threadpool_h_
+
+#include <stddef.h>
+
+/**
+ * Abstract thread pool API.
+ *
+ * Applications can implement this interface to provide custom threading
+ * backends (e.g., Windows thread pool, custom work-stealing scheduler, etc.).
+ *
+ * The API is designed for batch job processing: submit multiple jobs, then
+ * wait for all to complete. This matches the KangarooTwelve tree hashing
+ * pattern where chunk processing is distributed across threads.
+ */
+typedef struct KT_ThreadPool_API {
+    /**
+     * Minimum input size (in bytes) required to enable parallel processing.
+     *
+     * If the total input size is smaller than this threshold, KangarooTwelve
+     * will not use threading for that particular Update() call, avoiding
+     * thread overhead for small inputs.
+     *
+     * Default: 2097152 (2 MB)
+     * Rationale: Threading overhead outweighs benefits for small inputs.
+     *            Optimal results typically seen with inputs > 10 MB.
+     */
+    size_t min_input_size_for_threading;
+
+    /**
+     * Create a thread pool with the specified number of worker threads.
+     *
+     * @param num_threads  Number of worker threads to create.
+     *                     If 1, implementation may skip thread creation overhead.
+     * @return Opaque pool handle on success, NULL on failure
+     * @note This is called once during KangarooTwelve initialization
+     */
+    void* (*create)(int num_threads);
+
+    /**
+     * Submit work to the thread pool.
+     *
+     * The work function will be called with work_data as its argument.
+     * Multiple jobs may be submitted before calling wait_all().
+     *
+     * @param pool       Opaque pool handle from create()
+     * @param work_fn    Function to execute (called as work_fn(work_data))
+     * @param work_data  Opaque pointer passed to work_fn
+     * @return 0 on success, non-zero on error
+     * @note work_fn must be thread-safe and not access shared mutable state
+     */
+    int (*submit)(void* pool, void (*work_fn)(void*), void* work_data);
+
+    /**
+     * Wait for all submitted work to complete.
+     *
+     * Blocks until all jobs submitted since the last wait_all() have finished.
+     * After this returns, it is safe to submit new work.
+     *
+     * @param pool  Opaque pool handle from create()
+     * @note This may be called multiple times to wait for different batches
+     */
+    void (*wait_all)(void* pool);
+
+    /**
+     * Destroy the thread pool and free all resources.
+     *
+     * All work must be complete before calling this (call wait_all() first).
+     * After destruction, the pool handle must not be used.
+     *
+     * @param pool  Opaque pool handle from create()
+     * @note This is called during KangarooTwelve cleanup
+     */
+    void (*destroy)(void* pool);
+} KT_ThreadPool_API;
+
+/**
+ * Built-in thread pool backend using POSIX threads (pthreads).
+ *
+ * Available on Linux, macOS, BSD, and other Unix-like systems with pthread support.
+ * Provides true parallel execution using worker threads.
+ *
+ * This is the default backend on pthread-capable platforms.
+ */
+extern const KT_ThreadPool_API KT_ThreadPool_Pthread;
+
+/**
+ * Built-in sequential (no-threading) backend.
+ *
+ * Available on all platforms. Executes work functions immediately in the
+ * calling thread (no actual parallelism). Useful as a fallback on platforms
+ * without threading support or for testing/debugging.
+ *
+ * This is the default backend on platforms without pthread support.
+ */
+extern const KT_ThreadPool_API KT_ThreadPool_Sequential;
+
+/**
+ * Get the default thread pool API for the current platform.
+ *
+ * Returns pthread backend if available, otherwise sequential backend.
+ *
+ * @return Pointer to the default thread pool API
+ */
+const KT_ThreadPool_API* KT_ThreadPool_GetDefault(void);
+
+#endif /* _KT_threadpool_h_ */

--- a/lib/KangarooTwelve-threading.c
+++ b/lib/KangarooTwelve-threading.c
@@ -1,0 +1,257 @@
+/*
+K12 based on the eXtended Keccak Code Package (XKCP)
+https://github.com/XKCP/XKCP
+
+KangarooTwelve, designed by Guido Bertoni, Joan Daemen, Michaël Peeters, Gilles Van Assche, Ronny Van Keer and Benoît Viguier.
+
+Threading support implementation using portable thread pool abstraction.
+
+To the extent possible under law, the implementer has waived all copyright
+and related or neighboring rights to the source code in this file.
+http://creativecommons.org/publicdomain/zero/1.0/
+*/
+
+#include "KangarooTwelve-threading.h"
+#include "KangarooTwelve.h"
+#include "KT-threadpool.h"
+#include "KeccakP-1600-SnP.h"
+#include <stdlib.h>
+#include <string.h>
+
+/* Constants from KangarooTwelve.c */
+#define K12_chunkSize       8192
+#define K12_suffixLeaf      0x0B
+#define KT128_capacityInBytes   32
+#define KT256_capacityInBytes   64
+
+/* Thread pool configuration */
+#define MAX_THREADS 64
+#define MIN_CHUNKS_PER_THREAD 4
+
+/* Work item for chunk processing */
+typedef struct {
+    const unsigned char *input;
+    size_t start_chunk;
+    size_t end_chunk;
+    unsigned char *output;
+    int security_level;
+    int capacity_bytes;
+} ChunkWork;
+
+/* TurboSHAKE instance for local use */
+typedef struct {
+    uint8_t state[KeccakP1600_stateSizeInBytes];
+    unsigned int rate;
+    uint8_t byteIOIndex;
+    uint8_t squeezing;
+} TurboSHAKE_Instance_Local;
+
+/* Forward declarations */
+static void process_chunk_range(void *work_ptr);
+static void TurboSHAKE_Initialize_Local(TurboSHAKE_Instance_Local *instance, unsigned int capacity);
+static void TurboSHAKE_Absorb_Local(TurboSHAKE_Instance_Local *instance, const unsigned char *data, size_t dataByteLen);
+static void TurboSHAKE_AbsorbDomainSeparationByte_Local(TurboSHAKE_Instance_Local *instance, unsigned char D);
+static void TurboSHAKE_Squeeze_Local(TurboSHAKE_Instance_Local *instance, unsigned char *data, size_t dataByteLen);
+
+/* TurboSHAKE helper functions for thread-local processing */
+static void TurboSHAKE_Initialize_Local(TurboSHAKE_Instance_Local *instance, unsigned int capacity)
+{
+    KeccakP1600_Initialize(instance->state);
+    instance->rate = 1600 - capacity;
+    instance->byteIOIndex = 0;
+    instance->squeezing = 0;
+}
+
+static void TurboSHAKE_Absorb_Local(TurboSHAKE_Instance_Local *instance, const unsigned char *data, size_t dataByteLen)
+{
+    size_t i, j;
+    uint8_t partialBlock;
+    const unsigned char *curData;
+    const uint8_t rateInBytes = instance->rate/8;
+
+    i = 0;
+    curData = data;
+    while(i < dataByteLen) {
+        if ((instance->byteIOIndex == 0) && (dataByteLen-i >= rateInBytes)) {
+#ifdef KeccakP1600_12rounds_FastLoop_supported
+            j = KeccakP1600_12rounds_FastLoop_Absorb(instance->state, instance->rate/64, curData, dataByteLen - i);
+            i += j;
+            curData += j;
+#endif
+            for(j=dataByteLen-i; j>=rateInBytes; j-=rateInBytes) {
+                KeccakP1600_AddBytes(instance->state, curData, 0, rateInBytes);
+                KeccakP1600_Permute_12rounds(instance->state);
+                curData+=rateInBytes;
+            }
+            i = dataByteLen - j;
+        } else {
+            if (dataByteLen - i > (size_t)rateInBytes - instance->byteIOIndex) {
+                partialBlock = rateInBytes-instance->byteIOIndex;
+            } else {
+                partialBlock = (uint8_t)(dataByteLen - i);
+            }
+            i += partialBlock;
+
+            KeccakP1600_AddBytes(instance->state, curData, instance->byteIOIndex, partialBlock);
+            curData += partialBlock;
+            instance->byteIOIndex += partialBlock;
+            if (instance->byteIOIndex == rateInBytes) {
+                KeccakP1600_Permute_12rounds(instance->state);
+                instance->byteIOIndex = 0;
+            }
+        }
+    }
+}
+
+static void TurboSHAKE_AbsorbDomainSeparationByte_Local(TurboSHAKE_Instance_Local *instance, unsigned char D)
+{
+    const unsigned int rateInBytes = instance->rate/8;
+
+    KeccakP1600_AddByte(instance->state, D, instance->byteIOIndex);
+    if ((D >= 0x80) && (instance->byteIOIndex == (rateInBytes-1)))
+        KeccakP1600_Permute_12rounds(instance->state);
+    KeccakP1600_AddByte(instance->state, 0x80, rateInBytes-1);
+    KeccakP1600_Permute_12rounds(instance->state);
+    instance->byteIOIndex = 0;
+    instance->squeezing = 1;
+}
+
+static void TurboSHAKE_Squeeze_Local(TurboSHAKE_Instance_Local *instance, unsigned char *data, size_t dataByteLen)
+{
+    size_t i, j;
+    unsigned int partialBlock;
+    const unsigned int rateInBytes = instance->rate/8;
+    unsigned char *curData;
+
+    if (!instance->squeezing)
+        TurboSHAKE_AbsorbDomainSeparationByte_Local(instance, 0x01);
+
+    i = 0;
+    curData = data;
+    while(i < dataByteLen) {
+        if ((instance->byteIOIndex == rateInBytes) && (dataByteLen-i >= rateInBytes)) {
+            for(j=dataByteLen-i; j>=rateInBytes; j-=rateInBytes) {
+                KeccakP1600_Permute_12rounds(instance->state);
+                KeccakP1600_ExtractBytes(instance->state, curData, 0, rateInBytes);
+                curData+=rateInBytes;
+            }
+            i = dataByteLen - j;
+        } else {
+            if (instance->byteIOIndex == rateInBytes) {
+                KeccakP1600_Permute_12rounds(instance->state);
+                instance->byteIOIndex = 0;
+            }
+            if (dataByteLen-i > rateInBytes-instance->byteIOIndex)
+                partialBlock = rateInBytes-instance->byteIOIndex;
+            else
+                partialBlock = (unsigned int)(dataByteLen - i);
+            i += partialBlock;
+
+            KeccakP1600_ExtractBytes(instance->state, curData, instance->byteIOIndex, partialBlock);
+            curData += partialBlock;
+            instance->byteIOIndex += partialBlock;
+        }
+    }
+}
+
+/* Process a range of chunks - adapted to work as thread pool job */
+static void process_chunk_range(void *work_ptr)
+{
+    ChunkWork *work = (ChunkWork *)work_ptr;
+    TurboSHAKE_Instance_Local queueNode;
+    const unsigned char *chunk_ptr = work->input + (work->start_chunk * K12_chunkSize);
+    unsigned char *output_ptr = work->output + (work->start_chunk * work->capacity_bytes);
+
+    for (size_t i = work->start_chunk; i < work->end_chunk; i++) {
+        /* Initialize TurboSHAKE for this chunk */
+        TurboSHAKE_Initialize_Local(&queueNode, 2 * work->security_level);
+
+        /* Absorb the chunk */
+        TurboSHAKE_Absorb_Local(&queueNode, chunk_ptr, K12_chunkSize);
+
+        /* Finalize with domain separation */
+        TurboSHAKE_AbsorbDomainSeparationByte_Local(&queueNode, K12_suffixLeaf);
+
+        /* Squeeze out the chaining value */
+        TurboSHAKE_Squeeze_Local(&queueNode, output_ptr, work->capacity_bytes);
+
+        chunk_ptr += K12_chunkSize;
+        output_ptr += work->capacity_bytes;
+    }
+}
+
+/* Main function to process chunks in parallel */
+int KT_ProcessChunksThreaded(const KT_ThreadPool_API* threadpool_api,
+                             void* threadpool_handle,
+                             int thread_count,
+                             const unsigned char *input,
+                             size_t chunkCount,
+                             unsigned char *output,
+                             int securityLevel)
+{
+    if (chunkCount == 0)
+        return 1;
+
+    /* No threading configured - should not happen, but handle gracefully */
+    if (!threadpool_api || !threadpool_handle || thread_count < 1)
+        return 1;
+
+    /* Determine capacity in bytes */
+    int capacity_bytes = (securityLevel == 128) ? KT128_capacityInBytes : KT256_capacityInBytes;
+
+    /* Determine how many threads to use */
+    int threads_to_use = thread_count;
+    if (chunkCount < (size_t)(threads_to_use * MIN_CHUNKS_PER_THREAD)) {
+        threads_to_use = (int)(chunkCount / MIN_CHUNKS_PER_THREAD);
+        if (threads_to_use < 1)
+            threads_to_use = 1;
+    }
+
+    /* If only one thread, process sequentially without thread overhead */
+    if (threads_to_use == 1) {
+        ChunkWork work;
+        work.input = input;
+        work.start_chunk = 0;
+        work.end_chunk = chunkCount;
+        work.output = output;
+        work.security_level = securityLevel;
+        work.capacity_bytes = capacity_bytes;
+        process_chunk_range(&work);
+        return 0;
+    }
+
+    /* Allocate work items for parallel processing */
+    ChunkWork* work_items = (ChunkWork*)malloc(threads_to_use * sizeof(ChunkWork));
+    if (!work_items)
+        return 1;
+
+    /* Distribute work among threads */
+    size_t chunks_per_thread = chunkCount / threads_to_use;
+    size_t extra_chunks = chunkCount % threads_to_use;
+
+    size_t current_chunk = 0;
+    for (int i = 0; i < threads_to_use; i++) {
+        size_t this_thread_chunks = chunks_per_thread + (i < (int)extra_chunks ? 1 : 0);
+
+        work_items[i].input = input;
+        work_items[i].start_chunk = current_chunk;
+        work_items[i].end_chunk = current_chunk + this_thread_chunks;
+        work_items[i].output = output;
+        work_items[i].security_level = securityLevel;
+        work_items[i].capacity_bytes = capacity_bytes;
+
+        /* Submit work to thread pool */
+        if (threadpool_api->submit(threadpool_handle, process_chunk_range, &work_items[i]) != 0) {
+            free(work_items);
+            return 1;
+        }
+
+        current_chunk += this_thread_chunks;
+    }
+
+    /* Wait for all work to complete */
+    threadpool_api->wait_all(threadpool_handle);
+
+    free(work_items);
+    return 0;
+}

--- a/lib/KangarooTwelve-threading.h
+++ b/lib/KangarooTwelve-threading.h
@@ -1,0 +1,49 @@
+/*
+K12 based on the eXtended Keccak Code Package (XKCP)
+https://github.com/XKCP/XKCP
+
+KangarooTwelve, designed by Guido Bertoni, Joan Daemen, Michaël Peeters, Gilles Van Assche, Ronny Van Keer and Benoît Viguier.
+
+Threading support implementation using portable thread pool abstraction.
+
+PLATFORM COMPATIBILITY:
+The library uses a portable thread pool abstraction that supports multiple backends:
+- Built-in pthread backend (Linux, macOS, BSD, Unix-like systems)
+- Built-in sequential backend (all platforms, no actual parallelism)
+- Custom application-provided backends (see KT-threadpool.h)
+
+By default, the pthread backend is used on systems with pthread support,
+and the sequential backend is used elsewhere.
+
+To the extent possible under law, the implementer has waived all copyright
+and related or neighboring rights to the source code in this file.
+http://creativecommons.org/publicdomain/zero/1.0/
+*/
+
+#ifndef _KangarooTwelve_threading_h_
+#define _KangarooTwelve_threading_h_
+
+#include <stddef.h>
+#include "KT-threadpool.h"
+
+/**
+ * Internal function to process multiple chunks in parallel using threads.
+ *
+ * @param threadpool_api    Thread pool API implementation
+ * @param threadpool_handle Thread pool handle
+ * @param thread_count      Number of threads in the pool
+ * @param input             Pointer to input data (multiple chunks)
+ * @param chunkCount        Number of chunks to process
+ * @param output            Pointer to output buffer for chaining values
+ * @param securityLevel     128 for KT128 or 256 for KT256
+ * @return 0 if successful, 1 otherwise
+ */
+int KT_ProcessChunksThreaded(const KT_ThreadPool_API* threadpool_api,
+                             void* threadpool_handle,
+                             int thread_count,
+                             const unsigned char *input,
+                             size_t chunkCount,
+                             unsigned char *output,
+                             int securityLevel);
+
+#endif /* _KangarooTwelve_threading_h_ */

--- a/lib/KangarooTwelve.h
+++ b/lib/KangarooTwelve.h
@@ -37,6 +37,10 @@ typedef struct KangarooTwelve_InstanceStruct {
     unsigned int queueAbsorbedLen;
     int phase;
     int securityLevel;
+    /* Thread pool for parallel chunk processing (optional, can be NULL) */
+    const void* threadpool_api;  /* KT_ThreadPool_API* */
+    void* threadpool_handle;
+    int thread_count;
 } KangarooTwelve_Instance;
 
 /** Extendable ouput function KangarooTwelve.
@@ -71,11 +75,34 @@ int KT256(const unsigned char *input, size_t inputByteLen, unsigned char *output
   */
 int KangarooTwelve_Initialize(KangarooTwelve_Instance *ktInstance, int securityLevel, size_t outputByteLen);
 
+/**
+  * Function to initialize a KangarooTwelve instance with threading support.
+  * @param  ktInstance      Pointer to the instance to be initialized.
+  * @param  securityLevel   128 for KT128 or 256 for KT256
+  * @param  outputByteLen   The desired number of output bytes,
+  *                         or 0 for an arbitrarily-long output.
+  * @param  threadpool_api  Thread pool API (NULL for no threading).
+  *                         Must point to a KT_ThreadPool_API struct.
+  * @param  threadpool_handle  Thread pool handle (from threadpool_api->create()).
+  *                            Ignored if threadpool_api is NULL.
+  * @param  thread_count    Number of threads in the pool.
+  *                         Ignored if threadpool_api is NULL.
+  * @return 0 if successful, 1 otherwise.
+  */
+int KangarooTwelve_Initialize_Threaded(KangarooTwelve_Instance *ktInstance, int securityLevel, size_t outputByteLen,
+                                       const void *threadpool_api, void *threadpool_handle, int thread_count);
+
 #define KT128_Initialize(instance, outputByteLen) \
-    KangarooTwelve_Initialize((instance), 128, (outputByteLen));
+    KangarooTwelve_Initialize((instance), 128, (outputByteLen))
 
 #define KT256_Initialize(instance, outputByteLen) \
-    KangarooTwelve_Initialize((instance), 256, (outputByteLen));
+    KangarooTwelve_Initialize((instance), 256, (outputByteLen))
+
+#define KT128_Initialize_Threaded(instance, outputByteLen, threadpool_api, threadpool_handle, thread_count) \
+    KangarooTwelve_Initialize_Threaded((instance), 128, (outputByteLen), (threadpool_api), (threadpool_handle), (thread_count))
+
+#define KT256_Initialize_Threaded(instance, outputByteLen, threadpool_api, threadpool_handle, thread_count) \
+    KangarooTwelve_Initialize_Threaded((instance), 256, (outputByteLen), (threadpool_api), (threadpool_handle), (thread_count))
 
 /**
   * Function to give input data to be absorbed.


### PR DESCRIPTION
This adds support for parallel processing using multiple threads for K12.

The thread pool implementation is defined as an interface, which means it can be easily replaced. The code provides both a simple sequential (non-threaded) implementation and a pthread-based one, but any custom implementation can be used.

Example result on a Macbook (1 GB input):

```text
  | Configuration             | Time          | Throughput     | Speedup          |
  |---------------------------|---------------|----------------|------------------|
  | Without Threading         | 0.448 seconds | 2,283.77 MB/s  | 1.00x (baseline) |
  | With Threading (10 thr.)  | 0.083 seconds | 12,386.00 MB/s | 5.42x            |
```

On an AMD CPU  (1 GB input):

```text
  | Configuration             | Time          | Throughput     | Speedup          |
  |---------------------------|---------------|----------------|------------------|
  | Without Threading         | 0.824 seconds | 1,242.23 MB/s  | 1.00x (baseline) |
  | With Threading (10 thr.)  | 0.127 seconds | 8,054.11 MB/s  | 6.48x            |
```
