### PR TITLE
Improve performance of the threaded mode

### DIFF
--- a/lib/KangarooTwelve-threading.c
+++ b/lib/KangarooTwelve-threading.c
@@ -26,7 +26,24 @@ http://creativecommons.org/publicdomain/zero/1.0/
 
 /* Thread pool configuration */
 #define MAX_THREADS 64
-#define MIN_CHUNKS_PER_THREAD 4
+#define MIN_CHUNKS_PER_THREAD 8
+
+/* Batch-based work distribution */
+#define CHUNKS_PER_BATCH 32      /* 32 chunks = 256 KB per batch - matches Zig */
+#define MAX_BATCHES 256          /* Maximum concurrent batches */
+
+/* SIMD leaf processing functions (from KeccakP-1600-runtimeDispatch.c) */
+#ifndef KeccakP1600_disableParallelism
+void KT128_Process2Leaves(const unsigned char *input, unsigned char *output);
+void KT128_Process4Leaves(const unsigned char *input, unsigned char *output);
+void KT128_Process8Leaves(const unsigned char *input, unsigned char *output);
+void KT256_Process2Leaves(const unsigned char *input, unsigned char *output);
+void KT256_Process4Leaves(const unsigned char *input, unsigned char *output);
+void KT256_Process8Leaves(const unsigned char *input, unsigned char *output);
+int KeccakP1600times2_IsAvailable(void);
+int KeccakP1600times4_IsAvailable(void);
+int KeccakP1600times8_IsAvailable(void);
+#endif
 
 /* Work item for chunk processing */
 typedef struct {
@@ -154,33 +171,110 @@ static void TurboSHAKE_Squeeze_Local(TurboSHAKE_Instance_Local *instance, unsign
     }
 }
 
+/* Process a single chunk without SIMD (scalar fallback) */
+static void process_single_chunk(const unsigned char *input, unsigned char *output,
+                                 int security_level, int capacity_bytes)
+{
+    TurboSHAKE_Instance_Local queueNode;
+
+    /* Initialize TurboSHAKE for this chunk */
+    TurboSHAKE_Initialize_Local(&queueNode, 2 * security_level);
+
+    /* Absorb the chunk */
+    TurboSHAKE_Absorb_Local(&queueNode, input, K12_chunkSize);
+
+    /* Finalize with domain separation */
+    TurboSHAKE_AbsorbDomainSeparationByte_Local(&queueNode, K12_suffixLeaf);
+
+    /* Squeeze out the chaining value */
+    TurboSHAKE_Squeeze_Local(&queueNode, output, capacity_bytes);
+}
+
 /* Process a range of chunks - adapted to work as thread pool job */
 static void process_chunk_range(void *work_ptr)
 {
     ChunkWork *work = (ChunkWork *)work_ptr;
-    TurboSHAKE_Instance_Local queueNode;
     const unsigned char *chunk_ptr = work->input + (work->start_chunk * K12_chunkSize);
     unsigned char *output_ptr = work->output + (work->start_chunk * work->capacity_bytes);
+    size_t chunks_remaining = work->end_chunk - work->start_chunk;
 
-    for (size_t i = work->start_chunk; i < work->end_chunk; i++) {
-        /* Initialize TurboSHAKE for this chunk */
-        TurboSHAKE_Initialize_Local(&queueNode, 2 * work->security_level);
+#ifndef KeccakP1600_disableParallelism
+    /* Use SIMD parallelism when available - process 8/4/2 chunks at a time */
+    if (work->security_level == 128) {
+        /* KT128 mode */
+        if (KeccakP1600times8_IsAvailable()) {
+            while (chunks_remaining >= 8) {
+                KT128_Process8Leaves(chunk_ptr, output_ptr);
+                chunk_ptr += 8 * K12_chunkSize;
+                output_ptr += 8 * KT128_capacityInBytes;
+                chunks_remaining -= 8;
+            }
+        }
 
-        /* Absorb the chunk */
-        TurboSHAKE_Absorb_Local(&queueNode, chunk_ptr, K12_chunkSize);
+        if (KeccakP1600times4_IsAvailable()) {
+            while (chunks_remaining >= 4) {
+                KT128_Process4Leaves(chunk_ptr, output_ptr);
+                chunk_ptr += 4 * K12_chunkSize;
+                output_ptr += 4 * KT128_capacityInBytes;
+                chunks_remaining -= 4;
+            }
+        }
 
-        /* Finalize with domain separation */
-        TurboSHAKE_AbsorbDomainSeparationByte_Local(&queueNode, K12_suffixLeaf);
+        if (KeccakP1600times2_IsAvailable()) {
+            while (chunks_remaining >= 2) {
+                KT128_Process2Leaves(chunk_ptr, output_ptr);
+                chunk_ptr += 2 * K12_chunkSize;
+                output_ptr += 2 * KT128_capacityInBytes;
+                chunks_remaining -= 2;
+            }
+        }
+    } else {
+        /* KT256 mode */
+        if (KeccakP1600times8_IsAvailable()) {
+            while (chunks_remaining >= 8) {
+                KT256_Process8Leaves(chunk_ptr, output_ptr);
+                chunk_ptr += 8 * K12_chunkSize;
+                output_ptr += 8 * KT256_capacityInBytes;
+                chunks_remaining -= 8;
+            }
+        }
 
-        /* Squeeze out the chaining value */
-        TurboSHAKE_Squeeze_Local(&queueNode, output_ptr, work->capacity_bytes);
+        if (KeccakP1600times4_IsAvailable()) {
+            while (chunks_remaining >= 4) {
+                KT256_Process4Leaves(chunk_ptr, output_ptr);
+                chunk_ptr += 4 * K12_chunkSize;
+                output_ptr += 4 * KT256_capacityInBytes;
+                chunks_remaining -= 4;
+            }
+        }
 
+        if (KeccakP1600times2_IsAvailable()) {
+            while (chunks_remaining >= 2) {
+                KT256_Process2Leaves(chunk_ptr, output_ptr);
+                chunk_ptr += 2 * K12_chunkSize;
+                output_ptr += 2 * KT256_capacityInBytes;
+                chunks_remaining -= 2;
+            }
+        }
+    }
+#endif  /* KeccakP1600_disableParallelism */
+
+    /* Process any remaining chunks with scalar code */
+    while (chunks_remaining > 0) {
+        process_single_chunk(chunk_ptr, output_ptr,
+                            work->security_level, work->capacity_bytes);
         chunk_ptr += K12_chunkSize;
         output_ptr += work->capacity_bytes;
+        chunks_remaining--;
     }
 }
 
-/* Main function to process chunks in parallel */
+/* Main function to process chunks in parallel
+ *
+ * Each batch is CHUNKS_PER_BATCH chunks (256 KB), which:
+ * - Is large enough to amortize task scheduling overhead
+ * - Is small enough to allow good load balancing via work-stealing
+ */
 int KT_ProcessChunksThreaded(const KT_ThreadPool_API* threadpool_api,
                              void* threadpool_handle,
                              int thread_count,
@@ -199,16 +293,11 @@ int KT_ProcessChunksThreaded(const KT_ThreadPool_API* threadpool_api,
     /* Determine capacity in bytes */
     int capacity_bytes = (securityLevel == 128) ? KT128_capacityInBytes : KT256_capacityInBytes;
 
-    /* Determine how many threads to use */
-    int threads_to_use = thread_count;
-    if (chunkCount < (size_t)(threads_to_use * MIN_CHUNKS_PER_THREAD)) {
-        threads_to_use = (int)(chunkCount / MIN_CHUNKS_PER_THREAD);
-        if (threads_to_use < 1)
-            threads_to_use = 1;
-    }
+    /* Calculate number of batches needed */
+    size_t num_batches = (chunkCount + CHUNKS_PER_BATCH - 1) / CHUNKS_PER_BATCH;
 
-    /* If only one thread, process sequentially without thread overhead */
-    if (threads_to_use == 1) {
+    /* If only one batch worth of work, process sequentially */
+    if (num_batches <= 1) {
         ChunkWork work;
         work.input = input;
         work.start_chunk = 0;
@@ -220,36 +309,45 @@ int KT_ProcessChunksThreaded(const KT_ThreadPool_API* threadpool_api,
         return 0;
     }
 
-    /* Allocate work items for parallel processing */
-    ChunkWork* work_items = (ChunkWork*)malloc(threads_to_use * sizeof(ChunkWork));
+    /* Cap number of batches to avoid excessive overhead */
+    if (num_batches > MAX_BATCHES)
+        num_batches = MAX_BATCHES;
+
+    /* Allocate work items for batch processing */
+    ChunkWork* work_items = (ChunkWork*)malloc(num_batches * sizeof(ChunkWork));
     if (!work_items)
         return 1;
 
-    /* Distribute work among threads */
-    size_t chunks_per_thread = chunkCount / threads_to_use;
-    size_t extra_chunks = chunkCount % threads_to_use;
-
+    /* Distribute chunks evenly across batches
+     * When batch count is capped, ensure balanced distribution
+     * instead of giving all remaining chunks to the last batch.
+     */
+    size_t chunks_per_batch = chunkCount / num_batches;
+    size_t extra_chunks = chunkCount % num_batches;
     size_t current_chunk = 0;
-    for (int i = 0; i < threads_to_use; i++) {
-        size_t this_thread_chunks = chunks_per_thread + (i < (int)extra_chunks ? 1 : 0);
+
+    for (size_t i = 0; i < num_batches; i++) {
+        /* First 'extra_chunks' batches get one additional chunk */
+        size_t batch_chunks = chunks_per_batch + (i < extra_chunks ? 1 : 0);
 
         work_items[i].input = input;
         work_items[i].start_chunk = current_chunk;
-        work_items[i].end_chunk = current_chunk + this_thread_chunks;
+        work_items[i].end_chunk = current_chunk + batch_chunks;
         work_items[i].output = output;
         work_items[i].security_level = securityLevel;
         work_items[i].capacity_bytes = capacity_bytes;
 
-        /* Submit work to thread pool */
-        if (threadpool_api->submit(threadpool_handle, process_chunk_range, &work_items[i]) != 0) {
+        /* Submit batch to thread pool */
+        if (threadpool_api->submit(threadpool_handle, process_chunk_range,
+                                   &work_items[i]) != 0) {
             free(work_items);
             return 1;
         }
 
-        current_chunk += this_thread_chunks;
+        current_chunk += batch_chunks;
     }
 
-    /* Wait for all work to complete */
+    /* Wait for all batches to complete */
     threadpool_api->wait_all(threadpool_handle);
 
     free(work_items);

--- a/lib/KangarooTwelve.c
+++ b/lib/KangarooTwelve.c
@@ -285,12 +285,7 @@ int KangarooTwelve_Update(KangarooTwelve_Instance *ktInstance, const unsigned ch
                                         ktInstance->thread_count,
                                         input, full_chunks, chaining_values, ktInstance->securityLevel) == 0) {
                 /* Successfully processed chunks in parallel */
-                /* Absorb all chaining values into finalNode in order */
-                for (size_t i = 0; i < full_chunks; i++) {
-                    TurboSHAKE_Absorb(&ktInstance->finalNode,
-                                     chaining_values + (i * capacityInBytes),
-                                     capacityInBytes);
-                }
+                TurboSHAKE_Absorb(&ktInstance->finalNode, chaining_values, full_chunks * capacityInBytes);
                 ktInstance->blockNumber += full_chunks;
 
                 /* Update input pointer and length */


### PR DESCRIPTION
Use vectorized KT128/KT256 Process2/4/8Leaves functions for chunk processing, with automatic fallback based on CPU capabilities.

Adapted from Zig's implementation, using batch-based work distribution with work-stealing for better load balancing.

```text
test bench_0001_kib          ... bench:       1,084.25 ns/iter (+/- 7.39) = 944 MB/s
test bench_0002_kib          ... bench:       1,947.26 ns/iter (+/- 9.87) = 1051 MB/s
test bench_0002_mib          ... bench:     386,693.40 ns/iter (+/- 2,783.66) = 5423 MB/s
test bench_0004_kib          ... bench:       3,677.84 ns/iter (+/- 14.48) = 1113 MB/s
test bench_0004_mib          ... bench:     758,535.10 ns/iter (+/- 5,637.14) = 5529 MB/s
test bench_0008_kib          ... bench:       7,492.86 ns/iter (+/- 156.45) = 1093 MB/s
test bench_0008_mib          ... bench:   1,505,700.90 ns/iter (+/- 6,798.64) = 5571 MB/s
test bench_0016_kib          ... bench:      14,596.51 ns/iter (+/- 31.32) = 1122 MB/s
test bench_0016_mib          ... bench:   2,999,719.10 ns/iter (+/- 20,010.40) = 5592 MB/s
test bench_0032_kib          ... bench:      20,235.30 ns/iter (+/- 98.89) = 1619 MB/s
test bench_0064_kib          ... bench:      26,420.15 ns/iter (+/- 123.21) = 2480 MB/s
test bench_0128_kib          ... bench:      37,889.05 ns/iter (+/- 105.94) = 3459 MB/s
test bench_0128_mib          ... bench:  24,694,581.30 ns/iter (+/- 244,646.49) = 5435 MB/s
test bench_0256_kib          ... bench:      60,924.19 ns/iter (+/- 173.49) = 4302 MB/s
test bench_0512_kib          ... bench:     107,099.59 ns/iter (+/- 270.36) = 4895 MB/s
test bench_1024_kib          ... bench:     200,493.58 ns/iter (+/- 743.02) = 5229 MB/s
test bench_1024_kib_k12      ... bench:   1,168,178.50 ns/iter (+/- 6,777.42) = 897 MB/s
test bench_threaded_0002_mib ... bench:     387,128.30 ns/iter (+/- 2,497.39) = 5417 MB/s
test bench_threaded_0004_mib ... bench:     149,872.15 ns/iter (+/- 18,826.11) = 27985 MB/s
test bench_threaded_0008_mib ... bench:     265,786.20 ns/iter (+/- 41,886.99) = 31561 MB/s
test bench_threaded_0016_mib ... bench:     484,063.24 ns/iter (+/- 34,470.30) = 34659 MB/s
test bench_threaded_0032_mib ... bench:     930,169.74 ns/iter (+/- 48,912.13) = 36073 MB/s
test bench_threaded_0064_mib ... bench:   1,809,901.10 ns/iter (+/- 162,005.26) = 37078 MB/s
test bench_threaded_0128_mib ... bench:   3,643,205.45 ns/iter (+/- 270,441.12) = 36840 MB/s
```