### PR TITLE
Fix threadpool races and CPU feature data races

### DIFF
--- a/Makefile.build
+++ b/Makefile.build
@@ -85,6 +85,7 @@ http://creativecommons.org/publicdomain/zero/1.0/
     <fragment name="common">
         <h>lib/align.h</h>
         <h>lib/brg_endian.h</h>
+        <h>lib/KT-atomic.h</h>
     </fragment>
 
     <!-- To run many tests -->

--- a/lib/ARMv8Asha3/KeccakP-1600-runtimeDispatch.c
+++ b/lib/ARMv8Asha3/KeccakP-1600-runtimeDispatch.c
@@ -188,6 +188,12 @@ void KangarooTwelve_SetArmProcessorCapabilities() {
 #endif  // KeccakP1600_enable_simd_options
 }
 
+static void ensure_arm_capabilities(void) {
+    if (g_arm_cpu_features == ARM_UNDEFINED) {
+        KangarooTwelve_SetArmProcessorCapabilities();
+    }
+}
+
 /* ---------------------------------------------------------------- */
 /* External function declarations */
 /* ---------------------------------------------------------------- */
@@ -212,7 +218,6 @@ extern void KT256_ARMv8Asha3_Process2Leaves(const unsigned char *input, unsigned
 /* ---------------------------------------------------------------- */
 
 const char * KeccakP1600_GetImplementation() {
-    KangarooTwelve_SetArmProcessorCapabilities();
     if (K12_enableARM_SHA3) {
         return "ARMv8-A+SHA3 optimized implementation";
     } else {
@@ -221,22 +226,19 @@ const char * KeccakP1600_GetImplementation() {
 }
 
 void KeccakP1600_Initialize(void *state) {
-    KangarooTwelve_SetArmProcessorCapabilities();
+    ensure_arm_capabilities();
     KeccakP1600_opt64_Initialize(state);  // Both use same initialization
 }
 
 void KeccakP1600_AddByte(void *state, unsigned char data, unsigned int offset) {
-    KangarooTwelve_SetArmProcessorCapabilities();
     KeccakP1600_opt64_AddByte(state, data, offset);  // Both use same AddByte
 }
 
 void KeccakP1600_AddBytes(void *state, const unsigned char *data, unsigned int offset, unsigned int length) {
-    KangarooTwelve_SetArmProcessorCapabilities();
     KeccakP1600_opt64_AddBytes(state, data, offset, length);  // Both use same AddBytes
 }
 
 void KeccakP1600_Permute_12rounds(void *state) {
-    KangarooTwelve_SetArmProcessorCapabilities();
     if (K12_enableARM_SHA3) {
         KeccakP1600_ARMv8Asha3_Permute_12rounds(state);
     } else {
@@ -245,12 +247,10 @@ void KeccakP1600_Permute_12rounds(void *state) {
 }
 
 void KeccakP1600_ExtractBytes(const void *state, unsigned char *data, unsigned int offset, unsigned int length) {
-    KangarooTwelve_SetArmProcessorCapabilities();
     KeccakP1600_opt64_ExtractBytes(state, data, offset, length);  // Both use same ExtractBytes
 }
 
 size_t KeccakP1600_12rounds_FastLoop_Absorb(void *state, unsigned int laneCount, const unsigned char *data, size_t dataByteLen) {
-    KangarooTwelve_SetArmProcessorCapabilities();
     if (K12_enableARM_SHA3) {
         return KeccakP1600_ARMv8Asha3_12rounds_FastLoop_Absorb(state, laneCount, data, dataByteLen);
     } else {
@@ -263,12 +263,10 @@ size_t KeccakP1600_12rounds_FastLoop_Absorb(void *state, unsigned int laneCount,
 /* ---------------------------------------------------------------- */
 
 int KeccakP1600times2_IsAvailable() {
-    KangarooTwelve_SetArmProcessorCapabilities();
     return K12_enableARM_SHA3;
 }
 
 const char * KeccakP1600times2_GetImplementation() {
-    KangarooTwelve_SetArmProcessorCapabilities();
     if (K12_enableARM_SHA3) {
         return "ARMv8-A+SHA3 optimized implementation";
     } else {
@@ -277,21 +275,18 @@ const char * KeccakP1600times2_GetImplementation() {
 }
 
 void KeccakP1600times2_Permute_12rounds(void *state) {
-    KangarooTwelve_SetArmProcessorCapabilities();
     if (K12_enableARM_SHA3) {
         KeccakP1600times2_ARMv8Asha3_Permute_12rounds(state);
     }
 }
 
 void KT128_Process2Leaves(const unsigned char *input, unsigned char *output) {
-    KangarooTwelve_SetArmProcessorCapabilities();
     if (K12_enableARM_SHA3) {
         KT128_ARMv8Asha3_Process2Leaves(input, output);
     }
 }
 
 void KT256_Process2Leaves(const unsigned char *input, unsigned char *output) {
-    KangarooTwelve_SetArmProcessorCapabilities();
     if (K12_enableARM_SHA3) {
         KT256_ARMv8Asha3_Process2Leaves(input, output);
     }

--- a/lib/ARMv8Asha3/KeccakP-1600-runtimeDispatch.c
+++ b/lib/ARMv8Asha3/KeccakP-1600-runtimeDispatch.c
@@ -23,6 +23,7 @@ ARM CPU feature detection adapted from libaegis by Frank Denis.
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include "KT-atomic.h"
 #include "KeccakP-1600-SnP.h"
 
 #ifdef KeccakP1600_disableParallelism
@@ -33,12 +34,12 @@ ARM CPU feature detection adapted from libaegis by Frank Denis.
 void KangarooTwelve_SetArmProcessorCapabilities();
 
 #ifdef KeccakP1600_enable_simd_options
-int K12_NEON_requested_disabled = 0;
-int K12_ARM_SHA3_requested_disabled = 0;
+K12_ATOMIC(int) K12_NEON_requested_disabled = 0;
+K12_ATOMIC(int) K12_ARM_SHA3_requested_disabled = 0;
 #endif  // KeccakP1600_enable_simd_options
 
-int K12_enableNEON = 0;
-int K12_enableARM_SHA3 = 0;
+K12_ATOMIC(int) K12_enableNEON = 0;
+K12_ATOMIC(int) K12_enableARM_SHA3 = 0;
 
 /* ---------------------------------------------------------------- */
 /* Platform-specific includes for CPU feature detection */
@@ -95,7 +96,7 @@ enum arm_cpu_feature {
     ARM_UNDEFINED = 1 << 30
 };
 
-static enum arm_cpu_feature g_arm_cpu_features = ARM_UNDEFINED;
+static K12_ATOMIC(int) g_arm_cpu_features = ARM_UNDEFINED;
 
 #if defined(K12_HAVE_LINUX_ARM) && defined(K12_HAVE_GETAUXVAL)
 static int _have_hwcap(unsigned long hwcap_bit) {

--- a/lib/KT-atomic.h
+++ b/lib/KT-atomic.h
@@ -1,0 +1,20 @@
+/*
+K12 based on the eXtended Keccak Code Package (XKCP)
+https://github.com/XKCP/XKCP
+
+To the extent possible under law, the implementer has waived all copyright
+and related or neighboring rights to the source code in this file.
+http://creativecommons.org/publicdomain/zero/1.0/
+*/
+
+#ifndef KT_ATOMIC_H
+#define KT_ATOMIC_H
+
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L) && !defined(__STDC_NO_ATOMICS__)
+#include <stdatomic.h>
+#define K12_ATOMIC(type) _Atomic(type)
+#else
+#define K12_ATOMIC(type) type
+#endif
+
+#endif  /* KT_ATOMIC_H */

--- a/lib/KT-threadpool-pthread.c
+++ b/lib/KT-threadpool-pthread.c
@@ -39,6 +39,7 @@ typedef struct {
     int job_count;
     int jobs_grabbed;    /* Number of jobs grabbed by workers */
     int jobs_finished;   /* Number of jobs actually completed */
+    int batch_ready;     /* Workers may only run jobs after wait_all() starts a batch */
 
     /* Synchronization */
     pthread_mutex_t mutex;
@@ -60,8 +61,9 @@ static void* worker_thread(void* arg)
     while (1) {
         pthread_mutex_lock(&pool->mutex);
 
-        /* Wait for work or shutdown */
-        while (!pool->shutdown && pool->jobs_grabbed >= pool->job_count) {
+        /* Wait for wait_all() to start a batch, more work in that batch, or shutdown */
+        while (!pool->shutdown &&
+               (!pool->batch_ready || pool->jobs_grabbed >= pool->job_count)) {
             pthread_cond_wait(&pool->work_available, &pool->mutex);
         }
 
@@ -89,7 +91,7 @@ static void* worker_thread(void* arg)
             pthread_mutex_lock(&pool->mutex);
             pool->jobs_finished++;
             if (pool->jobs_finished >= pool->job_count) {
-                pthread_cond_signal(&pool->work_complete);
+                pthread_cond_broadcast(&pool->work_complete);
             }
             pthread_mutex_unlock(&pool->mutex);
         }
@@ -155,6 +157,7 @@ static void* pthread_create_pool(int num_threads)
     pool->job_count = 0;
     pool->jobs_grabbed = 0;
     pool->jobs_finished = 0;
+    pool->batch_ready = 0;
 
     for (int i = 0; i < num_threads; i++) {
         pool->thread_ids[i] = i;
@@ -187,9 +190,9 @@ static int pthread_submit(void* pool_handle, void (*work_fn)(void*), void* work_
 
     pthread_mutex_lock(&pool->mutex);
 
-    if (pool->job_count >= MAX_JOBS) {
+    if (pool->batch_ready || pool->job_count >= MAX_JOBS) {
         pthread_mutex_unlock(&pool->mutex);
-        return 1;  /* Job queue full */
+        return 1;  /* Batch already running or job queue full */
     }
 
     pool->job_queue[pool->job_count].work_fn = work_fn;
@@ -210,20 +213,27 @@ static void pthread_wait_all(void* pool_handle)
 
     pthread_mutex_lock(&pool->mutex);
 
-    /* Reset counters and wake up workers */
-    pool->jobs_grabbed = 0;
-    pool->jobs_finished = 0;
-    pthread_cond_broadcast(&pool->work_available);
+    if (!pool->batch_ready) {
+        /* Start this batch and wake up workers */
+        pool->jobs_grabbed = 0;
+        pool->jobs_finished = 0;
+        pool->batch_ready = 1;
+        pthread_cond_broadcast(&pool->work_available);
+    }
 
-    /* Wait for all jobs to finish execution */
-    while (pool->jobs_finished < pool->job_count) {
+    /* Wait for all jobs in the active batch to finish execution */
+    while (pool->batch_ready && pool->jobs_finished < pool->job_count) {
         pthread_cond_wait(&pool->work_complete, &pool->mutex);
     }
 
-    /* Reset for next batch */
-    pool->job_count = 0;
-    pool->jobs_grabbed = 0;
-    pool->jobs_finished = 0;
+    if (pool->batch_ready) {
+        /* Reset for next batch */
+        pool->job_count = 0;
+        pool->jobs_grabbed = 0;
+        pool->jobs_finished = 0;
+        pool->batch_ready = 0;
+        pthread_cond_broadcast(&pool->work_complete);
+    }
 
     pthread_mutex_unlock(&pool->mutex);
 }

--- a/lib/KT-threadpool-sequential.c
+++ b/lib/KT-threadpool-sequential.c
@@ -16,16 +16,8 @@ http://creativecommons.org/publicdomain/zero/1.0/
 #include "KT-threadpool.h"
 #include <stdlib.h>
 
-#define MAX_JOBS 256
-
 /* Sequential pool context */
 typedef struct {
-    /* Job queue */
-    struct {
-        void (*work_fn)(void*);
-        void* work_data;
-    } jobs[MAX_JOBS];
-    int job_count;
     int valid;  /* Marker to detect use-after-free */
 } SequentialPool;
 
@@ -39,45 +31,28 @@ static void* sequential_create_pool(int num_threads)
     if (!pool)
         return NULL;
 
-    pool->job_count = 0;
     pool->valid = 0x12345678;  /* Magic number for validation */
 
     return pool;
 }
 
-/* Submit work to sequential pool (just queue it) */
+/* Submit work to sequential pool (execute it synchronously) */
 static int sequential_submit(void* pool_handle, void (*work_fn)(void*), void* work_data)
 {
     SequentialPool* pool = (SequentialPool*)pool_handle;
     if (!pool || pool->valid != 0x12345678 || !work_fn)
         return 1;
 
-    if (pool->job_count >= MAX_JOBS)
-        return 1;  /* Job queue full */
-
-    pool->jobs[pool->job_count].work_fn = work_fn;
-    pool->jobs[pool->job_count].work_data = work_data;
-    pool->job_count++;
-
+    work_fn(work_data);
     return 0;
 }
 
-/* Wait for all work (execute queued jobs sequentially) */
+/* Work is completed before sequential_submit returns. */
 static void sequential_wait_all(void* pool_handle)
 {
     SequentialPool* pool = (SequentialPool*)pool_handle;
     if (!pool || pool->valid != 0x12345678)
         return;
-
-    /* Execute all queued jobs sequentially */
-    for (int i = 0; i < pool->job_count; i++) {
-        if (pool->jobs[i].work_fn) {
-            pool->jobs[i].work_fn(pool->jobs[i].work_data);
-        }
-    }
-
-    /* Reset for next batch */
-    pool->job_count = 0;
 }
 
 /* Destroy sequential pool */

--- a/lib/KangarooTwelve-threading.c
+++ b/lib/KangarooTwelve-threading.c
@@ -340,6 +340,8 @@ int KT_ProcessChunksThreaded(const KT_ThreadPool_API* threadpool_api,
         /* Submit batch to thread pool */
         if (threadpool_api->submit(threadpool_handle, process_chunk_range,
                                    &work_items[i]) != 0) {
+            if (i > 0)
+                threadpool_api->wait_all(threadpool_handle);
             free(work_items);
             return 1;
         }

--- a/lib/Optimized64/KeccakP-1600-runtimeDispatch.c
+++ b/lib/Optimized64/KeccakP-1600-runtimeDispatch.c
@@ -31,6 +31,7 @@ Please refer to the XKCP for more details.
 
 // Forward declaration
 void KangarooTwelve_SetProcessorCapabilities();
+static void ensure_capabilities(void);
 #ifdef KeccakP1600_enable_simd_options
 K12_ATOMIC(int) K12_SSSE3_requested_disabled = 0;
 K12_ATOMIC(int) K12_AVX2_requested_disabled = 0;
@@ -178,7 +179,7 @@ const char * KeccakP1600_GetImplementation()
 
 void KeccakP1600_Initialize(void *state)
 {
-    KangarooTwelve_SetProcessorCapabilities();
+    ensure_capabilities();
     if (K12_enableAVX512)
         KeccakP1600_AVX512_Initialize(state);
     else
@@ -393,6 +394,12 @@ void KangarooTwelve_SetProcessorCapabilities()
     K12_enableAVX2 = K12_enableAVX2 && !K12_AVX2_requested_disabled;
     K12_enableAVX512 = K12_enableAVX512 && !K12_AVX512_requested_disabled;
 #endif  // KeccakP1600_enable_simd_options
+}
+
+static void ensure_capabilities(void) {
+    if (g_cpu_features == UNDEFINED) {
+        KangarooTwelve_SetProcessorCapabilities();
+    }
 }
 
 #ifdef KeccakP1600_enable_simd_options

--- a/lib/Optimized64/KeccakP-1600-runtimeDispatch.c
+++ b/lib/Optimized64/KeccakP-1600-runtimeDispatch.c
@@ -22,6 +22,7 @@ Please refer to the XKCP for more details.
 #include <stdlib.h>
 #include <string.h>
 #include "brg_endian.h"
+#include "KT-atomic.h"
 #include "KeccakP-1600-SnP.h"
 
 #ifdef KeccakP1600_disableParallelism
@@ -31,13 +32,13 @@ Please refer to the XKCP for more details.
 // Forward declaration
 void KangarooTwelve_SetProcessorCapabilities();
 #ifdef KeccakP1600_enable_simd_options
-int K12_SSSE3_requested_disabled = 0;
-int K12_AVX2_requested_disabled = 0;
-int K12_AVX512_requested_disabled = 0;
+K12_ATOMIC(int) K12_SSSE3_requested_disabled = 0;
+K12_ATOMIC(int) K12_AVX2_requested_disabled = 0;
+K12_ATOMIC(int) K12_AVX512_requested_disabled = 0;
 #endif  // KeccakP1600_enable_simd_options
-int K12_enableSSSE3 = 0;
-int K12_enableAVX2 = 0;
-int K12_enableAVX512 = 0;
+K12_ATOMIC(int) K12_enableSSSE3 = 0;
+K12_ATOMIC(int) K12_enableAVX2 = 0;
+K12_ATOMIC(int) K12_enableAVX512 = 0;
 
 /* ---------------------------------------------------------------- */
 
@@ -327,7 +328,7 @@ enum cpu_feature {
   UNDEFINED = 1 << 30
 };
 
-static enum cpu_feature g_cpu_features = UNDEFINED;
+static K12_ATOMIC(int) g_cpu_features = UNDEFINED;
 
 static enum cpu_feature
     get_cpu_features(void) {


### PR DESCRIPTION
These changes  should address the multithreading races issues reported in #26.

The sequential threadpool now executes submitted work synchronously, while the pthread pool only lets workers process a batch after `wait_all()` starts it.

If submit fails after some work has already been queued, the threaded chunk
processor now waits for that work to finish before freeing its work items.

CPU flags are now atomic (unless the compiler doesn't support C11) to make TSAN happy.